### PR TITLE
nullability update

### DIFF
--- a/src/e2e/src/e2e.test.ts
+++ b/src/e2e/src/e2e.test.ts
@@ -202,9 +202,3 @@ test("Wrangler variables can be retrieved", async () => {
   assert.ok(res.ok, withRes("GET motd should be OK", res));
   assert.equal(res.data, "horse tinder is awesome");
 });
-
-test("Method Nullability", async () => {
-  let res = await Horse.returnNull();
-  assert.ok(res.ok, withRes("GET motd should be OK", res));
-  assert.equal(res.value, null);
-});

--- a/src/e2e/src/e2e.test.ts
+++ b/src/e2e/src/e2e.test.ts
@@ -194,11 +194,17 @@ test("Methods can return both data and errors", async () => {
   }
 });
 
-test("Wrangler variabels can be retrieved", async () => {
+test("Wrangler variables can be retrieved", async () => {
   // Act
   let res = await Horse.motd();
 
   // Assert
   assert.ok(res.ok, withRes("GET motd should be OK", res));
   assert.equal(res.data, "horse tinder is awesome");
+});
+
+test("Method Nullability", async () => {
+  let res = await Horse.returnNull();
+  assert.ok(res.ok, withRes("GET motd should be OK", res));
+  assert.equal(res.value, null);
 });

--- a/src/extractor/ts/src/common.ts
+++ b/src/extractor/ts/src/common.ts
@@ -1,4 +1,4 @@
-import { Named } from "cmd-ts/dist/cjs/helpdoc.js";
+import { boolean } from "cmd-ts";
 
 export type Either<L, R> = { ok: false; value: L } | { ok: true; value: R };
 export function left<L>(value: L): Either<L, never> {
@@ -41,15 +41,20 @@ export type HttpResult<T = unknown> = {
 };
 
 export type CidlType =
+  | "Void"
   | "Integer"
   | "Real"
   | "Text"
   | "Blob"
-  | "D1Database"
   | { Inject: string }
   | { Model: string }
+  | { Nullable: CidlType }
   | { Array: CidlType }
-  | { HttpResult: CidlType | null };
+  | { HttpResult: CidlType };
+
+export function isNullableType(ty: CidlType): boolean {
+  return typeof ty === "object" && ty !== null && "Nullable" in ty;
+}
 
 export enum HttpVerb {
   GET = "GET",
@@ -62,7 +67,6 @@ export enum HttpVerb {
 export interface NamedTypedValue {
   name: string;
   cidl_type: CidlType;
-  nullable: boolean;
 }
 
 export interface ModelAttribute {

--- a/src/extractor/ts/src/extract.ts
+++ b/src/extractor/ts/src/extract.ts
@@ -83,10 +83,10 @@ export class CidlExtractor {
       });
 
     if (wranglerEnvs.length < 1) {
-      left("Missing wrangler environment @WranglerEnv");
+      return left("Missing wrangler environment @WranglerEnv");
     }
     if (wranglerEnvs.length > 1) {
-      left("Too many wrangler environments specified with @WranglerEnv");
+      return left("Too many wrangler environments specified with @WranglerEnv");
     }
 
     return right({
@@ -114,12 +114,12 @@ export class CidlExtractor {
 
       // No decorators means this is a standard attribute
       if (decorators.length === 0) {
-        let typeRes = CidlExtractor.cidlType(prop.getType());
+        const typeRes = CidlExtractor.cidlType(prop.getType());
         if (!typeRes.ok) {
           return typeRes;
         }
 
-        let cidl_type = typeRes.value;
+        const cidl_type = typeRes.value;
         attributes.push({
           foreign_key_reference: null,
           value: {
@@ -134,13 +134,13 @@ export class CidlExtractor {
       const decorator = decorators[0];
       const name = getDecoratorName(decorator);
 
-      let typeRes = CidlExtractor.cidlType(prop.getType());
+      const typeRes = CidlExtractor.cidlType(prop.getType());
       if (!typeRes.ok) {
         return typeRes;
       }
 
       // Process decorators
-      let cidl_type = typeRes.value;
+      const cidl_type = typeRes.value;
       switch (name) {
         case AttributeDecoratorKind.PrimaryKey: {
           primary_key = {
@@ -213,7 +213,7 @@ export class CidlExtractor {
             );
           }
 
-          let treeRes = CidlExtractor.includeTree(
+          const treeRes = CidlExtractor.includeTree(
             initializer,
             classDecl,
             sourceFile,
@@ -277,10 +277,10 @@ export class CidlExtractor {
     }
 
     // Nullable via union
-    let [unwrappedType, nullable] = unwrapNullable(type);
+    const [unwrappedType, nullable] = unwrapNullable(type);
 
     // Primitives
-    let tyText = unwrappedType
+    const tyText = unwrappedType
       .getText(undefined, TypeFormatFlags.UseAliasDefinedOutsideCurrentScope)
       .split("|")[0]
       .trim(); // trim `| null` if there

--- a/src/extractor/ts/src/extract.ts
+++ b/src/extractor/ts/src/extract.ts
@@ -26,6 +26,7 @@ import {
   left,
   right,
 } from "./common.js";
+import { TypeFormatFlags } from "typescript";
 
 enum AttributeDecoratorKind {
   PrimaryKey = "PrimaryKey",
@@ -85,7 +86,7 @@ export class CidlExtractor {
       left("Missing wrangler environment @WranglerEnv");
     }
     if (wranglerEnvs.length > 1) {
-      // todo: err
+      left("Too many wrangler environments specified with @WranglerEnv");
     }
 
     return right({
@@ -118,13 +119,12 @@ export class CidlExtractor {
           return typeRes;
         }
 
-        let [cidl_type, nullable] = typeRes.value;
+        let cidl_type = typeRes.value;
         attributes.push({
           foreign_key_reference: null,
           value: {
             name: prop.getName(),
             cidl_type,
-            nullable,
           },
         });
         continue;
@@ -140,13 +140,12 @@ export class CidlExtractor {
       }
 
       // Process decorators
-      let [cidl_type, nullable] = typeRes.value;
+      let cidl_type = typeRes.value;
       switch (name) {
         case AttributeDecoratorKind.PrimaryKey: {
           primary_key = {
             name: prop.getName(),
             cidl_type,
-            nullable,
           };
           break;
         }
@@ -156,7 +155,6 @@ export class CidlExtractor {
             value: {
               name: prop.getName(),
               cidl_type,
-              nullable,
             },
           });
           break;
@@ -170,7 +168,7 @@ export class CidlExtractor {
           }
 
           navigationProperties.push({
-            value: { name: prop.getName(), cidl_type, nullable },
+            value: { name: prop.getName(), cidl_type },
             kind: { OneToOne: { reference } },
           });
           break;
@@ -187,7 +185,6 @@ export class CidlExtractor {
             value: {
               name: prop.getName(),
               cidl_type,
-              nullable,
             },
             kind: { OneToMany: { reference } },
           });
@@ -203,7 +200,6 @@ export class CidlExtractor {
             value: {
               name: prop.getName(),
               cidl_type,
-              nullable,
             },
             kind: { ManyToMany: { unique_id } },
           });
@@ -256,71 +252,113 @@ export class CidlExtractor {
     });
   }
 
-  /// Returns a `CidlType` from a TypeScript type, along with if the base value is nullable.
-  /// Throws an error if no type can be extracted.
+  private static readonly primTypeMap: Record<string, CidlType> = {
+    number: "Integer",
+    Number: "Integer",
+    string: "Text",
+    String: "Text",
+    boolean: "Integer",
+    Boolean: "Integer",
+    Date: "Text",
+  };
+
   private static cidlType(
     type: Type,
     inject: boolean = false,
-  ): Either<string, [CidlType, boolean]> {
-    let map: Record<string, CidlType> = {
-      number: "Integer", // TODO: It's wrong to assume number is always an int.
-      Number: "Integer",
-      string: "Text",
-      String: "Text",
-      boolean: "Integer",
-      Boolean: "Integer",
-      Date: "Text",
-    };
-
-    // TODO: We don't support type unions like Foo | Bar, should we?
-    let nullable = type.getUnionTypes().find((t) => t.isNull()) !== undefined;
-
-    // Split by generics and imports
-    let split = type.getText().split(/<|>|import\([^)]+\)\.?/);
-
-    let cidlType = split.reduceRight<CidlType | undefined>((acc, x) => {
-      // Strip unions
-      let base = x
-        .split("|")
-        .map((s) => s.trim())
-        .find((s) => s !== "null" && s !== "undefined")!;
-
-      // Disregard any promises, they have no meaning as of now
-      if (!base || base === "Promise") return acc!;
-
-      // Primitive or nullable primitive
-      if (map[base] !== undefined) return map[base];
-
-      // Array of primitive
-      if (base.endsWith("[]")) {
-        const item = base.slice(0, -2);
-        return map[item] !== undefined
-          ? { Array: map[item] }
-          : { Array: { Model: item } };
-      }
-
-      // Skip void
-      if (base == "void") return acc;
-
-      // Result wrapper
-      if (base === "HttpResult") {
-        return { HttpResult: acc == undefined ? null : acc };
-      }
-
-      // Inject wrapper
-      if (inject) {
-        return { Inject: base };
-      }
-
-      // Model wrapper
-      return { Model: base };
-    }, undefined);
-
-    if (cidlType === undefined) {
-      left(`Unknown or unsupported type ${type.getText()}`);
+  ): Either<string, CidlType> {
+    // Void
+    if (type.isVoid()) {
+      return right("Void");
     }
 
-    return right([cidlType!, nullable]);
+    // Null
+    if (type.isNull()) {
+      return right({ Nullable: "Void" });
+    }
+
+    // Nullable via union
+    let { ty: unwrappedType, nullable } = unwrapNullable(type);
+
+    // Primitives
+    let tyText = unwrappedType
+      .getText(undefined, TypeFormatFlags.UseAliasDefinedOutsideCurrentScope)
+      .split("|")[0]
+      .trim(); // trim `| null` if there
+    if (this.primTypeMap[tyText]) {
+      return right(
+        nullable
+          ? { Nullable: this.primTypeMap[tyText] }
+          : this.primTypeMap[tyText],
+      );
+    }
+
+    const generics = [
+      ...unwrappedType.getAliasTypeArguments(),
+      ...unwrappedType.getTypeArguments(),
+    ];
+    if (generics.length > 1) {
+      return left("Multiple generics are not yet supported");
+    }
+
+    if (generics.length < 1) {
+      // Inject
+      if (inject) {
+        return right({ Inject: tyText });
+      }
+
+      // Model
+      return right({ Model: tyText });
+    }
+
+    const genericTy = generics[0];
+
+    // Promise (ignore)
+    if (unwrappedType.getSymbol()?.getName() === "Promise") {
+      return res(genericTy, nullable, (inner) => inner);
+    }
+
+    // Array
+    if (unwrappedType.isArray()) {
+      return res(genericTy, nullable, (inner) => ({
+        Array: inner,
+      }));
+    }
+
+    // HttpResult
+    if (unwrappedType.getAliasSymbol()?.getName() === "HttpResult") {
+      return res(genericTy, nullable, (inner) => ({ HttpResult: inner }));
+    }
+
+    // IncludeTree (ignore)
+    if (unwrappedType.getAliasSymbol()?.getName() === "IncludeTree") {
+      return res(genericTy, nullable, (inner) => inner);
+    }
+
+    return left(`Unknown symbol ${tyText}`);
+
+    function res(
+      t: Type,
+      nullable: boolean,
+      wrapper: (inner: CidlType) => CidlType,
+    ): Either<string, CidlType> {
+      const res = CidlExtractor.cidlType(t, inject);
+      if (!res.ok) {
+        return res;
+      }
+      return right(
+        nullable ? { Nullable: wrapper(res.value) } : wrapper(res.value),
+      );
+    }
+
+    function unwrapNullable(ty: Type): { ty: Type; nullable: boolean } {
+      if (ty.isUnion()) {
+        const nonNull = ty.getUnionTypes().filter((t) => !t.isNull());
+        if (nonNull.length === 1) {
+          return { ty: nonNull[0], nullable: true };
+        }
+      }
+      return { ty, nullable: false };
+    }
   }
 
   // TODO: Should really be more descriptive with the errors here
@@ -337,7 +375,7 @@ export class CidlExtractor {
     for (const prop of expr.getProperties()) {
       if (!prop.isKind(SyntaxKind.PropertyAssignment)) continue;
 
-      let navProp = findPropertyByName(currentClass, prop.getName());
+      const navProp = findPropertyByName(currentClass, prop.getName());
       if (!navProp) {
         console.log(
           `  Warning: Could not find property "${prop.getName()}" in class ${currentClass.getName()}`,
@@ -345,20 +383,19 @@ export class CidlExtractor {
         continue;
       }
 
-      let typeRes = CidlExtractor.cidlType(navProp.getType());
+      const typeRes = CidlExtractor.cidlType(navProp.getType());
       if (!typeRes.ok) {
         return typeRes;
       }
 
-      let [cidl_type, _] = typeRes.value;
+      const cidl_type = typeRes.value;
       if (typeof cidl_type === "string") {
         return left(`Invalid include tree type ${cidl_type} expected Model`);
       }
 
-      const typedValue = {
+      const ntv: NamedTypedValue = {
         name: navProp.getName(),
         cidl_type,
-        nullable: false, // TODO: hardcoding this for now, it doesn't mean anything for the IncludeTree
       };
 
       // Recurse for nested includes
@@ -366,7 +403,7 @@ export class CidlExtractor {
       let nestedTree: CidlIncludeTree = [];
 
       if (initializer?.isKind?.(SyntaxKind.ObjectLiteralExpression)) {
-        let targetModel = getModelName(cidl_type);
+        const targetModel = getModelName(cidl_type);
         const targetClass = currentClass
           .getSourceFile()
           .getProject()
@@ -375,7 +412,11 @@ export class CidlExtractor {
           .find((c) => c.getName() === targetModel);
 
         if (targetClass) {
-          let treeRes = CidlExtractor.includeTree(initializer, targetClass, sf);
+          const treeRes = CidlExtractor.includeTree(
+            initializer,
+            targetClass,
+            sf,
+          );
           if (!treeRes.ok) {
             return treeRes;
           }
@@ -383,7 +424,7 @@ export class CidlExtractor {
         }
       }
 
-      result.push([typedValue, nestedTree]);
+      result.push([ntv, nestedTree]);
     }
 
     return right(result);
@@ -404,46 +445,41 @@ export class CidlExtractor {
     for (const param of method.getParameters()) {
       // Handle injected param
       if (param.getDecorator(ParameterDecoratorKind.Inject)) {
-        let typeRes = CidlExtractor.cidlType(param.getType(), true);
+        const typeRes = CidlExtractor.cidlType(param.getType(), true);
         if (!typeRes.ok) {
           return typeRes;
         }
-        let [cidl_type, nullable] = typeRes.value;
 
         parameters.push({
           name: param.getName(),
-          cidl_type: cidl_type,
-          nullable: false,
+          cidl_type: typeRes.value,
         });
         continue;
       }
 
       // Handle all other params
-      let typeRes = CidlExtractor.cidlType(param.getType());
+      const typeRes = CidlExtractor.cidlType(param.getType());
       if (!typeRes.ok) {
         return typeRes;
       }
 
-      let [cidl_type, nullable] = typeRes.value;
       parameters.push({
         name: param.getName(),
-        cidl_type,
-        nullable,
+        cidl_type: typeRes.value,
       });
     }
 
     // TODO: return types cant be nullable??
-    let typeRes = CidlExtractor.cidlType(method.getReturnType());
+    const typeRes = CidlExtractor.cidlType(method.getReturnType());
     if (!typeRes.ok) {
       return typeRes;
     }
-    let [return_type, _] = typeRes.value;
 
     return right({
       name: method.getName(),
       is_static: method.isStatic(),
       http_verb: httpVerb,
-      return_type,
+      return_type: typeRes.value,
       parameters,
     });
   }

--- a/src/extractor/ts/src/extract.ts
+++ b/src/extractor/ts/src/extract.ts
@@ -277,7 +277,7 @@ export class CidlExtractor {
     }
 
     // Nullable via union
-    let { ty: unwrappedType, nullable } = unwrapNullable(type);
+    let [unwrappedType, nullable] = unwrapNullable(type);
 
     // Primitives
     let tyText = unwrappedType
@@ -350,14 +350,14 @@ export class CidlExtractor {
       );
     }
 
-    function unwrapNullable(ty: Type): { ty: Type; nullable: boolean } {
+    function unwrapNullable(ty: Type): [Type, boolean] {
       if (ty.isUnion()) {
         const nonNull = ty.getUnionTypes().filter((t) => !t.isNull());
         if (nonNull.length === 1) {
-          return { ty: nonNull[0], nullable: true };
+          return [nonNull[0], true];
         }
       }
-      return { ty, nullable: false };
+      return [ty, false];
     }
   }
 

--- a/src/extractor/ts/tests/__snapshots__/extract.test.ts.snap
+++ b/src/extractor/ts/tests/__snapshots__/extract.test.ts.snap
@@ -11,15 +11,15 @@ exports[`actions snapshot 1`] = `
           "value": {
             "cidl_type": "Text",
             "name": "name",
-            "nullable": false,
           },
         },
         {
           "foreign_key_reference": null,
           "value": {
-            "cidl_type": "Text",
+            "cidl_type": {
+              "Nullable": "Text",
+            },
             "name": "bio",
-            "nullable": true,
           },
         },
       ],
@@ -35,7 +35,6 @@ exports[`actions snapshot 1`] = `
                   },
                 },
                 "name": "likes",
-                "nullable": false,
               },
               [
                 [
@@ -44,7 +43,6 @@ exports[`actions snapshot 1`] = `
                       "Model": "Horse",
                     },
                     "name": "horse2",
-                    "nullable": false,
                   },
                   [],
                 ],
@@ -64,14 +62,12 @@ exports[`actions snapshot 1`] = `
                 "Inject": "Env",
               },
               "name": "{ db }",
-              "nullable": false,
             },
             {
               "cidl_type": {
                 "Model": "Horse",
               },
               "name": "horse",
-              "nullable": false,
             },
           ],
           "return_type": {
@@ -90,12 +86,10 @@ exports[`actions snapshot 1`] = `
                 "Inject": "Env",
               },
               "name": "{ db }",
-              "nullable": false,
             },
             {
               "cidl_type": "Integer",
               "name": "id",
-              "nullable": false,
             },
           ],
           "return_type": {
@@ -114,7 +108,6 @@ exports[`actions snapshot 1`] = `
                 "Inject": "Env",
               },
               "name": "{ db }",
-              "nullable": false,
             },
           ],
           "return_type": {
@@ -135,18 +128,16 @@ exports[`actions snapshot 1`] = `
                 "Inject": "Env",
               },
               "name": "{ db }",
-              "nullable": false,
             },
             {
               "cidl_type": {
                 "Model": "Horse",
               },
               "name": "horse",
-              "nullable": false,
             },
           ],
           "return_type": {
-            "HttpResult": null,
+            "HttpResult": "Void",
           },
         },
         {
@@ -159,18 +150,16 @@ exports[`actions snapshot 1`] = `
                 "Inject": "Env",
               },
               "name": "{ db }",
-              "nullable": false,
             },
             {
               "cidl_type": {
                 "Model": "Horse",
               },
               "name": "horse",
-              "nullable": false,
             },
           ],
           "return_type": {
-            "HttpResult": null,
+            "HttpResult": "Void",
           },
         },
         {
@@ -181,16 +170,41 @@ exports[`actions snapshot 1`] = `
             {
               "cidl_type": "Integer",
               "name": "a",
-              "nullable": false,
             },
             {
               "cidl_type": "Integer",
               "name": "b",
-              "nullable": false,
             },
           ],
           "return_type": {
             "HttpResult": "Integer",
+          },
+        },
+        {
+          "http_verb": "POST",
+          "is_static": true,
+          "name": "returnNull",
+          "parameters": [],
+          "return_type": {
+            "Nullable": "Void",
+          },
+        },
+        {
+          "http_verb": "POST",
+          "is_static": true,
+          "name": "returnNullArrayOrNull",
+          "parameters": [
+            {
+              "cidl_type": {
+                "Nullable": "Integer",
+              },
+              "name": "count",
+            },
+          ],
+          "return_type": {
+            "Nullable": {
+              "Array": "Text",
+            },
           },
         },
       ],
@@ -209,14 +223,12 @@ exports[`actions snapshot 1`] = `
               },
             },
             "name": "likes",
-            "nullable": false,
           },
         },
       ],
       "primary_key": {
         "cidl_type": "Integer",
         "name": "id",
-        "nullable": false,
       },
       "source_path": "void for tests",
     },
@@ -227,7 +239,6 @@ exports[`actions snapshot 1`] = `
           "value": {
             "cidl_type": "Integer",
             "name": "horseId1",
-            "nullable": false,
           },
         },
         {
@@ -235,7 +246,6 @@ exports[`actions snapshot 1`] = `
           "value": {
             "cidl_type": "Integer",
             "name": "horseId2",
-            "nullable": false,
           },
         },
       ],
@@ -254,14 +264,12 @@ exports[`actions snapshot 1`] = `
               "Model": "Horse",
             },
             "name": "horse2",
-            "nullable": false,
           },
         },
       ],
       "primary_key": {
         "cidl_type": "Integer",
         "name": "id",
-        "nullable": false,
       },
       "source_path": "void for tests",
     },

--- a/src/extractor/ts/tests/cloesce.test.ts
+++ b/src/extractor/ts/tests/cloesce.test.ts
@@ -1,7 +1,5 @@
-import { WranglerEnv } from "../dist/common";
 import { _cloesceInternal } from "../src/cloesce";
 import {
-  CidlSpec,
   DataSource,
   HttpVerb,
   MetaCidl,
@@ -22,7 +20,6 @@ const makeCidl = (methods: Record<string, any>): MetaCidl => ({
       primary_key: {
         name: "void",
         cidl_type: "Integer",
-        nullable: false,
       },
       navigation_properties: [] as NavigationProperty[],
       data_sources: [] as DataSource[],
@@ -264,17 +261,20 @@ describe("Validate Request Error States", () => {
 });
 
 describe("Validate Request Success States", () => {
-  const input: { typed_value: NamedTypedValue; value: string }[] = [
+  const input: {
+    typed_value: NamedTypedValue;
+    value: string;
+  }[] = [
     {
-      typed_value: { name: "id", cidl_type: "Integer", nullable: true },
+      typed_value: { name: "id", cidl_type: "Integer" },
       value: "1",
     },
     {
-      typed_value: { name: "lastName", cidl_type: "Text", nullable: true },
+      typed_value: { name: "lastName", cidl_type: "Text" },
       value: "pumpkin",
     },
     {
-      typed_value: { name: "gpa", cidl_type: "Real", nullable: true },
+      typed_value: { name: "gpa", cidl_type: "Real" },
       value: "4.0",
     },
   ];
@@ -286,7 +286,12 @@ describe("Validate Request Success States", () => {
         ...i,
         is_get,
         value: nullable ? null : i.value,
-        typed_value: { ...i.typed_value, nullable },
+        typed_value: {
+          ...i.typed_value,
+          cidl_type: nullable
+            ? { Nullable: i.typed_value.cidl_type }
+            : i.typed_value.cidl_type,
+        },
       })),
     ),
   );
@@ -359,7 +364,10 @@ describe("modelsFromSql", () => {
         name: modelName,
         attributes: [
           {
-            value: { name: "name", cidl_type: "Text", nullable: true },
+            value: {
+              name: "name",
+              cidl_type: { Nullable: "Text" },
+            },
             foreign_key_reference: null,
           },
         ],
@@ -368,7 +376,6 @@ describe("modelsFromSql", () => {
             value: {
               name: "riders",
               cidl_type: { Array: { Model: nestedModelName } },
-              nullable: false,
             },
             kind: { OneToMany: { reference: "id" } },
           },
@@ -376,7 +383,6 @@ describe("modelsFromSql", () => {
         primary_key: {
           name: "id",
           cidl_type: "Integer",
-          nullable: false,
         },
         data_sources: [],
         methods: {},
@@ -385,14 +391,16 @@ describe("modelsFromSql", () => {
         name: nestedModelName,
         attributes: [
           {
-            value: { name: "nickname", cidl_type: "Text", nullable: true },
+            value: {
+              name: "nickname",
+              cidl_type: { Nullable: "Text" },
+            },
             foreign_key_reference: null,
           },
         ],
         primary_key: {
           name: "id",
           cidl_type: "Integer",
-          nullable: false,
         },
         navigation_properties: [],
         data_sources: [],

--- a/src/generator/client/src/lib.rs
+++ b/src/generator/client/src/lib.rs
@@ -1,19 +1,27 @@
 mod mappers;
 
-use std::sync::Arc;
+use std::{ops::Deref, sync::Arc};
 
-use common::{CidlSpec, CidlType, InputLanguage, match_cidl, matches_cidl};
+use common::{CidlSpec, CidlType, InputLanguage};
 use handlebars::{Handlebars, handlebars_helper};
 
 use mappers::TypeScriptMapper;
 
 pub trait ClientLanguageTypeMapper {
-    fn type_name(&self, ty: Option<&CidlType>, nullable: bool) -> String;
+    fn type_name(&self, ty: &CidlType) -> String;
 }
 
 handlebars_helper!(is_serializable: |cidl_type: CidlType| !matches!(cidl_type, CidlType::Inject(_)));
-handlebars_helper!(is_model: |cidl_type: CidlType| matches_cidl!(&cidl_type, Model(_)) || matches_cidl!(&cidl_type, HttpResult(Model(_))));
-handlebars_helper!(is_model_array: |cidl_type: CidlType| matches_cidl!(&cidl_type, HttpResult(Array(Model(_)))) || matches_cidl!(&cidl_type, Array(Model(_))));
+handlebars_helper!(is_model: |cidl_type: CidlType| match cidl_type {
+    CidlType::Model(_) => true,
+    CidlType::HttpResult(inner) => matches!(inner.deref(), CidlType::Model(_)),
+    _ => false,
+});
+handlebars_helper!(is_model_array: |cidl_type: CidlType| match cidl_type {
+    CidlType::HttpResult(inner) => matches!(inner.deref(), CidlType::Array(inner2) if matches!(inner2.deref(), CidlType::Model(_))),
+    CidlType::Array(inner) => matches!(inner.deref(), CidlType::Model(_)),
+    _ => false,
+});
 handlebars_helper!(eq: |a: str, b: str| a == b);
 
 fn register_helpers(
@@ -32,15 +40,10 @@ fn register_helpers(
                   _: &handlebars::Context,
                   _: &mut handlebars::RenderContext<'_, '_>,
                   out: &mut dyn handlebars::Output| {
-                let cidl_type: Option<CidlType> =
+                let cidl_type: CidlType =
                     serde_json::from_value(h.param(0).unwrap().value().clone()).unwrap();
 
-                let nullable: bool = h
-                    .param(1)
-                    .and_then(|v| v.value().as_bool())
-                    .unwrap_or(false);
-
-                let rendered = mapper.type_name(cidl_type.as_ref(), nullable);
+                let rendered = mapper.type_name(&cidl_type);
                 out.write(&rendered)?;
                 Ok(())
             },

--- a/src/generator/client/src/mappers.rs
+++ b/src/generator/client/src/mappers.rs
@@ -4,29 +4,28 @@ use crate::ClientLanguageTypeMapper;
 
 pub struct TypeScriptMapper;
 impl ClientLanguageTypeMapper for TypeScriptMapper {
-    fn type_name(&self, ty: Option<&CidlType>, nullable: bool) -> String {
-        let Some(ty) = ty else {
-            return "void".to_string();
-        };
-
-        let base = match ty {
+    fn type_name(&self, ty: &CidlType) -> String {
+        match ty {
             CidlType::Integer => "number".to_string(),
             CidlType::Real => "number".to_string(),
             CidlType::Text => "string".to_string(),
             CidlType::Blob => "Uint8Array".to_string(),
             CidlType::Model(name) => name.clone(),
+            CidlType::Nullable(inner) => {
+                if matches!(inner.as_ref(), CidlType::Void) {
+                    return "null".to_string();
+                }
+
+                let inner_ts = self.type_name(inner);
+                format!("{} | null", inner_ts)
+            }
             CidlType::Array(inner) => {
-                let inner_ts = self.type_name(Some(inner), nullable);
+                let inner_ts = self.type_name(inner);
                 format!("{}[]", inner_ts)
             }
-            CidlType::HttpResult(inner) => self.type_name(inner.as_deref(), nullable),
+            CidlType::HttpResult(inner) => self.type_name(inner),
+            CidlType::Void => "void".to_string(),
             invalid => panic!("Invalid TypeScript type, {:?}", invalid),
-        };
-
-        if nullable {
-            format!("{base} | null")
-        } else {
-            base
         }
     }
 }

--- a/src/generator/client/src/templates/ts.hbs
+++ b/src/generator/client/src/templates/ts.hbs
@@ -13,19 +13,19 @@ function instantiateModelArray<T extends object>(
 
 {{#each models}}
 export class {{name}} {
-  {{primary_key.name}}: {{lang_type primary_key.cidl_type primary_key.nullable}};
+  {{primary_key.name}}: {{lang_type primary_key.cidl_type}};
   {{#each attributes}}
-  {{value.name}}: {{lang_type value.cidl_type value.nullable}};
+  {{value.name}}: {{lang_type value.cidl_type}};
   {{/each}}
   {{#each navigation_properties}}
-  {{value.name}}: {{lang_type value.cidl_type value.nullable}};
+  {{value.name}}: {{lang_type value.cidl_type}};
   {{/each}}
 
   {{#each methods}}
   {{#if is_static}}static {{/if}}async {{name}}(
     {{#each parameters}}
       {{#if (is_serializable cidl_type)}}
-        {{name}}: {{lang_type cidl_type nullable}}{{#unless @last}}, {{/unless}}
+        {{name}}: {{lang_type cidl_type}}{{#unless @last}}, {{/unless}}
       {{/if}}
     {{/each}}
   ): Promise<HttpResult<{{lang_type return_type}}>> {

--- a/src/generator/common/src/builder.rs
+++ b/src/generator/common/src/builder.rs
@@ -36,7 +36,6 @@ impl IncludeTreeBuilder {
             NamedTypedValue {
                 name: name.into(),
                 cidl_type,
-                nullable: false,
             },
             IncludeTree(vec![]),
         ));
@@ -52,7 +51,6 @@ impl IncludeTreeBuilder {
             NamedTypedValue {
                 name: name.into(),
                 cidl_type,
-                nullable: false,
             },
             subtree,
         ));
@@ -92,14 +90,12 @@ impl ModelBuilder {
         mut self,
         name: impl Into<String>,
         cidl_type: CidlType,
-        nullable: bool,
         foreign_key: Option<String>,
     ) -> Self {
         self.attributes.push(ModelAttribute {
             value: NamedTypedValue {
                 name: name.into(),
                 cidl_type,
-                nullable,
             },
             foreign_key_reference: foreign_key,
         });
@@ -110,14 +106,12 @@ impl ModelBuilder {
         mut self,
         name: impl Into<String>,
         cidl_type: CidlType,
-        nullable: bool,
         foreign_key: NavigationPropertyKind,
     ) -> Self {
         self.navigation_properties.push(NavigationProperty {
             value: NamedTypedValue {
                 name: name.into(),
                 cidl_type,
-                nullable,
             },
             kind: foreign_key,
         });
@@ -128,7 +122,6 @@ impl ModelBuilder {
         self.primary_key = Some(NamedTypedValue {
             name: name.into(),
             cidl_type,
-            nullable: false,
         });
         self
     }
@@ -143,7 +136,7 @@ impl ModelBuilder {
         http_verb: HttpVerb,
         is_static: bool,
         parameters: Vec<NamedTypedValue>,
-        return_type: Option<CidlType>,
+        return_type: CidlType,
     ) -> Self {
         self.methods.push(ModelMethod {
             name: name.into(),

--- a/src/generator/d1/tests/d1_tests.rs
+++ b/src/generator/d1/tests/d1_tests.rs
@@ -1,5 +1,5 @@
 use common::{
-    CidlType, NavigationPropertyKind,
+    CidlType, NamedTypedValue, NavigationPropertyKind,
     builder::{IncludeTreeBuilder, ModelBuilder, create_cidl, create_wrangler},
 };
 use d1::D1Generator;
@@ -42,8 +42,8 @@ fn test_sqlite_table_output() {
         let cidl = create_cidl(vec![
             ModelBuilder::new("User")
                 .id() // adds a primary key
-                .attribute("name", CidlType::Text, true, None)
-                .attribute("age", CidlType::Integer, false, None)
+                .attribute("name", CidlType::nullable(CidlType::Text), None)
+                .attribute("age", CidlType::Integer, None)
                 .build(),
         ]);
         let d1gen = D1Generator::new(cidl, create_wrangler());
@@ -64,7 +64,7 @@ fn test_sqlite_table_output() {
         let cidl = create_cidl(vec![
             ModelBuilder::new("Person")
                 .id()
-                .attribute("dogId", CidlType::Integer, false, Some("Dog".to_string()))
+                .attribute("dogId", CidlType::Integer, Some("Dog".to_string()))
                 .build(),
             ModelBuilder::new("Dog").id().build(),
         ]);
@@ -86,11 +86,10 @@ fn test_sqlite_table_output() {
         let cidl = create_cidl(vec![
             ModelBuilder::new("Person")
                 .id()
-                .attribute("dogId", CidlType::Integer, false, Some("Dog".into()))
+                .attribute("dogId", CidlType::Integer, Some("Dog".into()))
                 .nav_p(
                     "dog",
                     CidlType::Model("Dog".into()),
-                    false,
                     NavigationPropertyKind::OneToOne {
                         reference: "dogId".into(),
                     },
@@ -116,38 +115,35 @@ fn test_sqlite_table_output() {
         let cidl = create_cidl(vec![
             ModelBuilder::new("Dog")
                 .id()
-                .attribute("personId", CidlType::Integer, false, Some("Person".into()))
+                .attribute("personId", CidlType::Integer, Some("Person".into()))
                 .build(),
             ModelBuilder::new("Cat")
-                .attribute("personId", CidlType::Integer, false, Some("Person".into()))
+                .attribute("personId", CidlType::Integer, Some("Person".into()))
                 .id()
                 .build(),
             ModelBuilder::new("Person")
                 .id()
                 .nav_p(
                     "dogs",
-                    CidlType::Array(Box::new(CidlType::Model("Dog".to_string()))),
-                    false,
+                    CidlType::array(CidlType::Model("Dog".to_string())),
                     NavigationPropertyKind::OneToMany {
                         reference: "personId".into(),
                     },
                 )
                 .nav_p(
                     "cats",
-                    CidlType::Array(Box::new(CidlType::Model("Cat".to_string()))),
-                    false,
+                    CidlType::array(CidlType::Model("Cat".to_string())),
                     NavigationPropertyKind::OneToMany {
                         reference: "personId".into(),
                     },
                 )
-                .attribute("bossId", CidlType::Integer, false, Some("Boss".into()))
+                .attribute("bossId", CidlType::Integer, Some("Boss".into()))
                 .build(),
             ModelBuilder::new("Boss")
                 .id()
                 .nav_p(
                     "persons",
-                    CidlType::Array(Box::new(CidlType::Model("Person".to_string()))),
-                    false,
+                    CidlType::array(CidlType::Model("Person".to_string())),
                     NavigationPropertyKind::OneToMany {
                         reference: "bossId".into(),
                     },
@@ -189,8 +185,7 @@ fn test_sqlite_table_output() {
                 .id()
                 .nav_p(
                     "courses",
-                    CidlType::Array(Box::new(CidlType::Model("Course".to_string()))),
-                    false,
+                    CidlType::array(CidlType::Model("Course".to_string())),
                     NavigationPropertyKind::ManyToMany {
                         unique_id: "StudentsCourses".into(),
                     },
@@ -200,8 +195,7 @@ fn test_sqlite_table_output() {
                 .id()
                 .nav_p(
                     "students",
-                    CidlType::Array(Box::new(CidlType::Model("Student".to_string()))),
-                    false,
+                    CidlType::array(CidlType::Model("Student".to_string())),
                     NavigationPropertyKind::ManyToMany {
                         unique_id: "StudentsCourses".into(),
                     },
@@ -241,11 +235,10 @@ fn test_sqlite_view_output() {
         let cidl = create_cidl(vec![
             ModelBuilder::new("Person")
                 .id()
-                .attribute("dogId", CidlType::Integer, false, Some("Dog".into()))
+                .attribute("dogId", CidlType::Integer, Some("Dog".into()))
                 .nav_p(
                     "dog",
                     CidlType::Model("Dog".into()),
-                    false,
                     NavigationPropertyKind::OneToOne {
                         reference: "dogId".into(),
                     },
@@ -278,10 +271,10 @@ fn test_sqlite_view_output() {
         let cidl = create_cidl(vec![
             ModelBuilder::new("Dog")
                 .id()
-                .attribute("personId", CidlType::Integer, false, Some("Person".into()))
+                .attribute("personId", CidlType::Integer, Some("Person".into()))
                 .build(),
             ModelBuilder::new("Cat")
-                .attribute("personId", CidlType::Integer, false, Some("Person".into()))
+                .attribute("personId", CidlType::Integer, Some("Person".into()))
                 .id()
                 .build(),
             ModelBuilder::new("Person")
@@ -289,7 +282,6 @@ fn test_sqlite_view_output() {
                 .nav_p(
                     "dogs",
                     CidlType::array(CidlType::Model("Dog".into())),
-                    false,
                     NavigationPropertyKind::OneToMany {
                         reference: "personId".into(),
                     },
@@ -297,12 +289,11 @@ fn test_sqlite_view_output() {
                 .nav_p(
                     "cats",
                     CidlType::array(CidlType::Model("Cat".into())),
-                    false,
                     NavigationPropertyKind::OneToMany {
                         reference: "personId".into(),
                     },
                 )
-                .attribute("bossId", CidlType::Integer, false, Some("Boss".into()))
+                .attribute("bossId", CidlType::Integer, Some("Boss".into()))
                 .data_source(
                     "default",
                     IncludeTreeBuilder::default()
@@ -316,7 +307,6 @@ fn test_sqlite_view_output() {
                 .nav_p(
                     "persons",
                     CidlType::array(CidlType::Model("Person".into())),
-                    false,
                     NavigationPropertyKind::OneToMany {
                         reference: "bossId".into(),
                     },
@@ -363,7 +353,6 @@ fn test_sqlite_view_output() {
                 .nav_p(
                     "courses",
                     CidlType::array(CidlType::Model("Course".to_string())),
-                    false,
                     NavigationPropertyKind::ManyToMany {
                         unique_id: "StudentsCourses".into(),
                     },
@@ -380,7 +369,6 @@ fn test_sqlite_view_output() {
                 .nav_p(
                     "students",
                     CidlType::array(CidlType::Model("Student".to_string())),
-                    false,
                     NavigationPropertyKind::ManyToMany {
                         unique_id: "StudentsCourses".into(),
                     },
@@ -421,13 +409,12 @@ fn test_sqlite_view_output() {
         let horse_model = ModelBuilder::new("Horse")
             // Attributes
             .id() // id is primary key
-            .attribute("name", CidlType::Text, false, None)
-            .attribute("bio", CidlType::Text, true, None)
+            .attribute("name", CidlType::Text, None)
+            .attribute("bio", CidlType::nullable(CidlType::Text), None)
             // Navigation Properties
             .nav_p(
                 "matches",
                 CidlType::array(CidlType::Model("Match".into())),
-                false,
                 NavigationPropertyKind::OneToMany {
                     reference: "horseId1".into(),
                 },
@@ -448,13 +435,12 @@ fn test_sqlite_view_output() {
         let match_model = ModelBuilder::new("Match")
             // Attributes
             .id()
-            .attribute("horseId1", CidlType::Integer, false, Some("Horse".into()))
-            .attribute("horseId2", CidlType::Integer, false, Some("Horse".into()))
+            .attribute("horseId1", CidlType::Integer, Some("Horse".into()))
+            .attribute("horseId2", CidlType::Integer, Some("Horse".into()))
             // Navigation Properties
             .nav_p(
                 "horse2",
                 CidlType::Model("Horse".into()),
-                false,
                 NavigationPropertyKind::OneToOne {
                     reference: "horseId2".into(),
                 },
@@ -482,8 +468,8 @@ fn test_duplicate_column_error() {
     let cidl = create_cidl(vec![
         ModelBuilder::new("Person")
             .id()
-            .attribute("name", CidlType::Integer, false, None)
-            .attribute("name", CidlType::Real, true, None)
+            .attribute("name", CidlType::Integer, None)
+            .attribute("name", CidlType::Real, None)
             .build(),
     ]);
 
@@ -500,7 +486,10 @@ fn test_duplicate_column_error() {
 fn test_nullable_primary_key_error() {
     // Arrange
     let mut model = ModelBuilder::new("Person").id().build();
-    model.primary_key.nullable = true;
+    model.primary_key = NamedTypedValue {
+        name: "id".into(),
+        cidl_type: CidlType::nullable(CidlType::Integer),
+    };
 
     let cidl = create_cidl(vec![model]);
     let d1gen = D1Generator::new(cidl, create_wrangler());
@@ -509,7 +498,7 @@ fn test_nullable_primary_key_error() {
     let err = d1gen.sql().unwrap_err();
 
     // Assert
-    expected_str!(err, "A primary key cannot be nullable.");
+    expected_str!(err, "Primary key cannot be nullable");
 }
 
 #[test]
@@ -537,7 +526,6 @@ fn test_unknown_foreign_key_error() {
             .attribute(
                 "nonExistentId",
                 CidlType::Integer,
-                false,
                 Some("NonExistent".to_string()),
             )
             .build(),
@@ -561,15 +549,15 @@ fn test_cycle_detection_error() {
     let cidl = create_cidl(vec![
         ModelBuilder::new("A")
             .id()
-            .attribute("bId", CidlType::Integer, false, Some("B".to_string()))
+            .attribute("bId", CidlType::Integer, Some("B".to_string()))
             .build(),
         ModelBuilder::new("B")
             .id()
-            .attribute("cId", CidlType::Integer, false, Some("C".to_string()))
+            .attribute("cId", CidlType::Integer, Some("C".to_string()))
             .build(),
         ModelBuilder::new("C")
             .id()
-            .attribute("aId", CidlType::Integer, false, Some("A".to_string()))
+            .attribute("aId", CidlType::Integer, Some("A".to_string()))
             .build(),
     ]);
 
@@ -588,15 +576,19 @@ fn test_nullability_prevents_cycle_error() {
     let cidl = create_cidl(vec![
         ModelBuilder::new("A")
             .id()
-            .attribute("bId", CidlType::Integer, false, Some("B".to_string()))
+            .attribute("bId", CidlType::Integer, Some("B".to_string()))
             .build(),
         ModelBuilder::new("B")
             .id()
-            .attribute("cId", CidlType::Integer, false, Some("C".to_string()))
+            .attribute("cId", CidlType::Integer, Some("C".to_string()))
             .build(),
         ModelBuilder::new("C")
             .id()
-            .attribute("aId", CidlType::Integer, true, Some("A".to_string()))
+            .attribute(
+                "aId",
+                CidlType::nullable(CidlType::Integer),
+                Some("A".to_string()),
+            )
             .build(),
     ]);
 
@@ -613,7 +605,7 @@ fn test_invalid_sqlite_type_error() {
     let cidl = create_cidl(vec![
         ModelBuilder::new("BadType")
             .id()
-            .attribute("attr", CidlType::Model("User".into()), false, None)
+            .attribute("attr", CidlType::Model("User".into()), None)
             .build(),
     ]);
 
@@ -636,7 +628,6 @@ fn test_one_to_one_nav_property_unknown_attribute_reference_error() {
             .nav_p(
                 "dog",
                 CidlType::Model("Dog".into()),
-                false,
                 NavigationPropertyKind::OneToOne {
                     reference: "dogId".to_string(),
                 },
@@ -667,7 +658,6 @@ fn test_one_to_one_nav_property_expected_model_type_error() {
             .nav_p(
                 "dog",
                 CidlType::Integer,
-                false,
                 NavigationPropertyKind::OneToOne {
                     reference: "dogId".to_string(),
                 },
@@ -695,11 +685,10 @@ fn test_one_to_one_mismatched_fk_and_nav_type_error() {
         ModelBuilder::new("Cat").id().build(),
         ModelBuilder::new("Person")
             .id()
-            .attribute("dogId", CidlType::Integer, false, Some("Dog".into()))
+            .attribute("dogId", CidlType::Integer, Some("Dog".into()))
             .nav_p(
                 "dog",
                 CidlType::Model("Cat".into()), // incorrect: says Cat but fk points to Dog
-                false,
                 NavigationPropertyKind::OneToOne {
                     reference: "dogId".to_string(),
                 },
@@ -725,14 +714,13 @@ fn test_one_to_many_expected_collection_type_error() {
     let spec = create_cidl(vec![
         ModelBuilder::new("Dog")
             .id()
-            .attribute("personId", CidlType::Integer, false, Some("Person".into()))
+            .attribute("personId", CidlType::Integer, Some("Person".into()))
             .build(),
         ModelBuilder::new("Person")
             .id()
             .nav_p(
                 "dogs",
                 CidlType::Model("Dog".into()), // wrong: not an array
-                false,
                 NavigationPropertyKind::OneToMany {
                     reference: "personId".into(),
                 },
@@ -761,8 +749,7 @@ fn test_one_to_many_nullable_nav_property_error() {
             .id()
             .nav_p(
                 "dogs",
-                CidlType::Array(Box::new(CidlType::Model("Dog".into()))),
-                true, // nullable -> should error
+                CidlType::null(), // nullable -> should error
                 NavigationPropertyKind::OneToMany {
                     reference: "personId".into(),
                 },
@@ -776,7 +763,10 @@ fn test_one_to_many_nullable_nav_property_error() {
     let err = d1gen.sql().unwrap_err();
 
     // Assert
-    expected_str!(err, "Navigation property cannot be nullable Person.dogs");
+    expected_str!(
+        err,
+        "Expected collection of Model type for navigation property Person.dogs"
+    );
 }
 
 #[test]
@@ -787,8 +777,7 @@ fn test_one_to_many_unknown_nav_model_error() {
             .id()
             .nav_p(
                 "dogs",
-                CidlType::Array(Box::new(CidlType::Model("Dog".into()))),
-                false,
+                CidlType::array(CidlType::Model("Dog".into())),
                 NavigationPropertyKind::OneToMany {
                     reference: "personId".into(),
                 },
@@ -819,8 +808,7 @@ fn test_one_to_many_unresolved_reference_error() {
             .id()
             .nav_p(
                 "dogs",
-                CidlType::Array(Box::new(CidlType::Model("Dog".to_string()))),
-                false,
+                CidlType::array(CidlType::Model("Dog".to_string())),
                 NavigationPropertyKind::OneToMany {
                     reference: "personId".into(),
                 },
@@ -849,7 +837,6 @@ fn test_many_to_many_expected_collection_type_error() {
             .nav_p(
                 "courses",
                 CidlType::Model("Course".into()), // wrong: not array
-                false,
                 NavigationPropertyKind::ManyToMany {
                     unique_id: "StudentsCourses".into(),
                 },
@@ -878,8 +865,7 @@ fn test_many_to_many_nullable_nav_property_error() {
             .id()
             .nav_p(
                 "courses",
-                CidlType::Array(Box::new(CidlType::Model("Course".into()))),
-                true, // nullable -> should error
+                CidlType::null(), // nullable, should err
                 NavigationPropertyKind::ManyToMany {
                     unique_id: "StudentsCourses".into(),
                 },
@@ -896,7 +882,7 @@ fn test_many_to_many_nullable_nav_property_error() {
     // Assert
     expected_str!(
         err,
-        "Navigation property cannot be nullable Student.courses"
+        "Expected collection of Model type for navigation property Student.courses"
     );
 }
 
@@ -908,8 +894,7 @@ fn test_many_to_many_unknown_nav_model_error() {
             .id()
             .nav_p(
                 "courses",
-                CidlType::Array(Box::new(CidlType::Model("Course".into()))),
-                false,
+                CidlType::array(CidlType::Model("Course".into())),
                 NavigationPropertyKind::ManyToMany {
                     unique_id: "StudentsCourses".into(),
                 },
@@ -939,8 +924,7 @@ fn test_junction_table_builder_errors() {
                 .id()
                 .nav_p(
                     "courses",
-                    CidlType::Array(Box::new(CidlType::Model("Course".into()))),
-                    false,
+                    CidlType::array(CidlType::Model("Course".into())),
                     NavigationPropertyKind::ManyToMany {
                         unique_id: "OnlyOne".into(),
                     },
@@ -962,8 +946,7 @@ fn test_junction_table_builder_errors() {
                 .id()
                 .nav_p(
                     "bs",
-                    CidlType::Array(Box::new(CidlType::Model("B".into()))),
-                    false,
+                    CidlType::array(CidlType::Model("B".into())),
                     NavigationPropertyKind::ManyToMany {
                         unique_id: "TriJ".into(),
                     },
@@ -973,8 +956,7 @@ fn test_junction_table_builder_errors() {
                 .id()
                 .nav_p(
                     "as",
-                    CidlType::Array(Box::new(CidlType::Model("A".into()))),
-                    false,
+                    CidlType::array(CidlType::Model("A".into())),
                     NavigationPropertyKind::ManyToMany {
                         unique_id: "TriJ".into(),
                     },
@@ -985,8 +967,7 @@ fn test_junction_table_builder_errors() {
                 .id()
                 .nav_p(
                     "as",
-                    CidlType::Array(Box::new(CidlType::Model("A".into()))),
-                    false,
+                    CidlType::array(CidlType::Model("A".into())),
                     NavigationPropertyKind::ManyToMany {
                         unique_id: "TriJ".into(),
                     },

--- a/src/generator/workers/src/lib.rs
+++ b/src/generator/workers/src/lib.rs
@@ -44,9 +44,7 @@ impl WorkersGenerator {
 
         for model in models {
             for method in &model.methods {
-                if let Some(Some(CidlType::Model(m))) =
-                    method.return_type.as_ref().map(|r| r.root_type())
-                {
+                if let CidlType::Model(m) = &method.return_type {
                     ensure!(
                         lookup.contains_key(m.as_str()),
                         "Unknown model reference on model method return type {}.{}",
@@ -64,6 +62,15 @@ impl WorkersGenerator {
                             param.name
                         );
                     };
+
+                    if let CidlType::Void = root_type {
+                        bail!(
+                            "Method parameters cannot be void. {}.{}.{}",
+                            model.name,
+                            method.name,
+                            param.name
+                        )
+                    }
 
                     if let CidlType::Model(m) = root_type {
                         ensure!(

--- a/src/test_fixtures/cidl.json
+++ b/src/test_fixtures/cidl.json
@@ -3,273 +3,255 @@
   "project_name": "e2e",
   "language": "TypeScript",
   "wrangler_env": {
-    "name": "Env",
-    "source_path": "/Users/benjaminschreiber/projects/cloesce/src/e2e/src/models/models.cloesce.ts"
+      "name": "Env",
+      "source_path": "/Users/benjaminschreiber/projects/cloesce/src/e2e/src/models/models.cloesce.ts"
   },
   "models": [
-    {
-      "name": "Horse",
-      "attributes": [
-        {
-          "foreign_key_reference": null,
-          "value": {
-            "name": "name",
-            "cidl_type": "Text",
-            "nullable": false
-          }
-        },
-        {
-          "foreign_key_reference": null,
-          "value": {
-            "name": "bio",
-            "cidl_type": "Text",
-            "nullable": true
-          }
-        }
-      ],
-      "primary_key": {
-        "name": "id",
-        "cidl_type": "Integer",
-        "nullable": false
-      },
-      "navigation_properties": [
-        {
-          "value": {
-            "name": "likes",
-            "cidl_type": {
-              "Array": {
-                "Model": "Like"
-              }
-            },
-            "nullable": false
-          },
-          "kind": {
-            "OneToMany": {
-              "reference": "horseId1"
-            }
-          }
-        }
-      ],
-      "methods": [
-        {
-          "name": "post",
-          "is_static": true,
-          "http_verb": "POST",
-          "return_type": {
-            "Model": "Horse"
-          },
-          "parameters": [
-            {
-              "name": "{ db }",
-              "cidl_type": {
-                "Inject": "Env"
-              },
-              "nullable": false
-            },
-            {
-              "name": "horse",
-              "cidl_type": {
-                "Model": "Horse"
-              },
-              "nullable": false
-            }
-          ]
-        },
-        {
-          "name": "get",
-          "is_static": true,
-          "http_verb": "GET",
-          "return_type": {
-            "Model": "Horse"
-          },
-          "parameters": [
-            {
-              "name": "{ db }",
-              "cidl_type": {
-                "Inject": "Env"
-              },
-              "nullable": false
-            },
-            {
-              "name": "id",
-              "cidl_type": "Integer",
-              "nullable": false
-            }
-          ]
-        },
-        {
-          "name": "list",
-          "is_static": true,
-          "http_verb": "GET",
-          "return_type": {
-            "Array": {
-              "Model": "Horse"
-            }
-          },
-          "parameters": [
-            {
-              "name": "{ db }",
-              "cidl_type": {
-                "Inject": "Env"
-              },
-              "nullable": false
-            }
-          ]
-        },
-        {
-          "name": "patch",
-          "is_static": false,
-          "http_verb": "PATCH",
-          "parameters": [
-            {
-              "name": "{ db }",
-              "cidl_type": {
-                "Inject": "Env"
-              },
-              "nullable": false
-            },
-            {
-              "name": "horse",
-              "cidl_type": {
-                "Model": "Horse"
-              },
-              "nullable": false
-            }
-          ]
-        },
-        {
-          "name": "like",
-          "is_static": false,
-          "http_verb": "POST",
-          "parameters": [
-            {
-              "name": "{ db }",
-              "cidl_type": {
-                "Inject": "Env"
-              },
-              "nullable": false
-            },
-            {
-              "name": "horse",
-              "cidl_type": {
-                "Model": "Horse"
-              },
-              "nullable": false
-            }
-          ]
-        },
-        {
-          "name": "divide",
-          "is_static": true,
-          "http_verb": "GET",
-          "return_type": {
-            "HttpResult": "Integer"
-          },
-          "parameters": [
-            {
-              "name": "a",
-              "cidl_type": "Integer",
-              "nullable": false
-            },
-            {
-              "name": "b",
-              "cidl_type": "Integer",
-              "nullable": false
-            }
-          ]
-        },
-        {
-          "name": "motd",
-          "is_static": true,
-          "http_verb": "GET",
-          "return_type": "Text",
-          "parameters": [
-            {
-              "name": "e",
-              "cidl_type": {
-                "Inject": "Env"
-              },
-              "nullable": false
-            }
-          ]
-        }
-      ],
-      "data_sources": [
-        {
-          "name": "default",
-          "tree": [
-            [
+      {
+          "name": "Horse",
+          "attributes": [
               {
-                "name": "likes",
-                "cidl_type": {
-                  "Array": {
-                    "Model": "Like"
+                  "foreign_key_reference": null,
+                  "value": {
+                      "name": "name",
+                      "cidl_type": "Text"
                   }
-                },
-                "nullable": false
               },
-              [
-                [
-                  {
-                    "name": "horse2",
-                    "cidl_type": {
-                      "Model": "Horse"
-                    },
-                    "nullable": false
-                  },
-                  []
-                ]
-              ]
-            ]
-          ]
-        }
-      ],
-      "source_path": "/Users/benjaminschreiber/projects/cloesce/src/e2e/src/models/models.cloesce.ts"
-    },
-    {
-      "name": "Like",
-      "attributes": [
-        {
-          "foreign_key_reference": "Horse",
-          "value": {
-            "name": "horseId1",
-            "cidl_type": "Integer",
-            "nullable": false
-          }
-        },
-        {
-          "foreign_key_reference": "Horse",
-          "value": {
-            "name": "horseId2",
-            "cidl_type": "Integer",
-            "nullable": false
-          }
-        }
-      ],
-      "primary_key": {
-        "name": "id",
-        "cidl_type": "Integer",
-        "nullable": false
-      },
-      "navigation_properties": [
-        {
-          "value": {
-            "name": "horse2",
-            "cidl_type": {
-              "Model": "Horse"
-            },
-            "nullable": false
+              {
+                  "foreign_key_reference": null,
+                  "value": {
+                      "name": "bio",
+                      "cidl_type": {
+                          "Nullable": "Text"
+                      }
+                  }
+              }
+          ],
+          "primary_key": {
+              "name": "id",
+              "cidl_type": "Integer"
           },
-          "kind": {
-            "OneToOne": {
-              "reference": "horseId2"
-            }
-          }
-        }
-      ],
-      "methods": [],
-      "data_sources": [],
-      "source_path": "/Users/benjaminschreiber/projects/cloesce/src/e2e/src/models/models.cloesce.ts"
-    }
+          "navigation_properties": [
+              {
+                  "value": {
+                      "name": "likes",
+                      "cidl_type": {
+                          "Array": {
+                              "Model": "Like"
+                          }
+                      }
+                  },
+                  "kind": {
+                      "OneToMany": {
+                          "reference": "horseId1"
+                      }
+                  }
+              }
+          ],
+          "methods": [
+              {
+                  "name": "post",
+                  "is_static": true,
+                  "http_verb": "POST",
+                  "return_type": {
+                      "Model": "Horse"
+                  },
+                  "parameters": [
+                      {
+                          "name": "{ db }",
+                          "cidl_type": {
+                              "Inject": "Env"
+                          }
+                      },
+                      {
+                          "name": "horse",
+                          "cidl_type": {
+                              "Model": "Horse"
+                          }
+                      }
+                  ]
+              },
+              {
+                  "name": "get",
+                  "is_static": true,
+                  "http_verb": "GET",
+                  "return_type": {
+                      "Model": "Horse"
+                  },
+                  "parameters": [
+                      {
+                          "name": "{ db }",
+                          "cidl_type": {
+                              "Inject": "Env"
+                          }
+                      },
+                      {
+                          "name": "id",
+                          "cidl_type": "Integer"
+                      }
+                  ]
+              },
+              {
+                  "name": "list",
+                  "is_static": true,
+                  "http_verb": "GET",
+                  "return_type": {
+                      "Array": {
+                          "Model": "Horse"
+                      }
+                  },
+                  "parameters": [
+                      {
+                          "name": "{ db }",
+                          "cidl_type": {
+                              "Inject": "Env"
+                          }
+                      }
+                  ]
+              },
+              {
+                  "name": "patch",
+                  "is_static": false,
+                  "http_verb": "PATCH",
+                  "return_type": "Void",
+                  "parameters": [
+                      {
+                          "name": "{ db }",
+                          "cidl_type": {
+                              "Inject": "Env"
+                          }
+                      },
+                      {
+                          "name": "horse",
+                          "cidl_type": {
+                              "Model": "Horse"
+                          }
+                      }
+                  ]
+              },
+              {
+                  "name": "like",
+                  "is_static": false,
+                  "http_verb": "POST",
+                  "return_type": "Void",
+                  "parameters": [
+                      {
+                          "name": "{ db }",
+                          "cidl_type": {
+                              "Inject": "Env"
+                          }
+                      },
+                      {
+                          "name": "horse",
+                          "cidl_type": {
+                              "Model": "Horse"
+                          }
+                      }
+                  ]
+              },
+              {
+                  "name": "divide",
+                  "is_static": true,
+                  "http_verb": "GET",
+                  "return_type": {
+                      "HttpResult": "Integer"
+                  },
+                  "parameters": [
+                      {
+                          "name": "a",
+                          "cidl_type": "Integer"
+                      },
+                      {
+                          "name": "b",
+                          "cidl_type": "Integer"
+                      }
+                  ]
+              },
+              {
+                  "name": "motd",
+                  "is_static": true,
+                  "http_verb": "GET",
+                  "return_type": "Text",
+                  "parameters": [
+                      {
+                          "name": "e",
+                          "cidl_type": {
+                              "Inject": "Env"
+                          }
+                      }
+                  ]
+              }
+          ],
+          "data_sources": [
+              {
+                  "name": "default",
+                  "tree": [
+                      [
+                          {
+                              "name": "likes",
+                              "cidl_type": {
+                                  "Array": {
+                                      "Model": "Like"
+                                  }
+                              }
+                          },
+                          [
+                              [
+                                  {
+                                      "name": "horse2",
+                                      "cidl_type": {
+                                          "Model": "Horse"
+                                      }
+                                  },
+                                  []
+                              ]
+                          ]
+                      ]
+                  ]
+              }
+          ],
+          "source_path": "/Users/benjaminschreiber/projects/cloesce/src/e2e/src/models/models.cloesce.ts"
+      },
+      {
+          "name": "Like",
+          "attributes": [
+              {
+                  "foreign_key_reference": "Horse",
+                  "value": {
+                      "name": "horseId1",
+                      "cidl_type": "Integer"
+                  }
+              },
+              {
+                  "foreign_key_reference": "Horse",
+                  "value": {
+                      "name": "horseId2",
+                      "cidl_type": "Integer"
+                  }
+              }
+          ],
+          "primary_key": {
+              "name": "id",
+              "cidl_type": "Integer"
+          },
+          "navigation_properties": [
+              {
+                  "value": {
+                      "name": "horse2",
+                      "cidl_type": {
+                          "Model": "Horse"
+                      }
+                  },
+                  "kind": {
+                      "OneToOne": {
+                          "reference": "horseId2"
+                      }
+                  }
+              }
+          ],
+          "methods": [],
+          "data_sources": [],
+          "source_path": "/Users/benjaminschreiber/projects/cloesce/src/e2e/src/models/models.cloesce.ts"
+      }
   ]
 }

--- a/src/test_fixtures/models.cloesce.ts
+++ b/src/test_fixtures/models.cloesce.ts
@@ -42,8 +42,17 @@ class Horse {
   async like(@Inject { db }: Env, horse: Horse): Promise<HttpResult<void>> {}
 
   /*  Random functions for test coverage  */
+
   @GET
   static async divide(a: number, b: number): Promise<HttpResult<number>> {}
+
+  @POST
+  static async returnNull(): Promise<null> {}
+
+  @POST
+  static async returnNullArrayOrNull(
+    count: number | null
+  ): Promise<string[] | null> {}
 }
 
 @D1


### PR DESCRIPTION
fixes #48 

Allows us to create more complex nullable types, like `HttpResult<Foo[] | null> | null>`, return just `null`, or even return a `null[]` if you're really having fun.