### PR TITLE
fix: make example use esm instead of cjs

### DIFF
--- a/examples/weather/package.json
+++ b/examples/weather/package.json
@@ -14,7 +14,7 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "type": "commonjs",
+  "type": "module",
   "dependencies": {
     "cloesce": "^0.0.5-unstable.27",
     "wrangler": "^4.61.1"


### PR DESCRIPTION
using node v20 if you create an example with `npx create-cloesce` it won't build since cmd-ts depends on chalk which is incompatible with commonjs
```
❯ npm run build                                                                                      ✭

> cloesce-proj@1.0.0 build
> cloesce compile && wrangler build

(node:9750) ExperimentalWarning: WASI is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
/Users/nwong/dev/tinytribe/node_modules/cmd-ts/dist/cjs/subcommands.js:40
const chalk_1 = __importDefault(require("chalk"));
                                ^

Error [ERR_REQUIRE_ESM]: require() of ES Module /Users/nwong/dev/tinytribe/node_modules/chalk/source/index.js from /Users/nwong/dev/tinytribe/node_modules/cmd-ts/dist/cjs/subcommands.js not supported.
Instead change the require of index.js in /Users/nwong/dev/tinytribe/node_modules/cmd-ts/dist/cjs/subcommands.js to a dynamic import() which is available in all CommonJS modules.
    at Object.<anonymous> (/Users/nwong/dev/tinytribe/node_modules/cmd-ts/dist/cjs/subcommands.js:40:33) {
  code: 'ERR_REQUIRE_ESM'
}

Node.js v20.16.
```