### PR TITLE
fix: formatter bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Fixed
 - Misc bugs in `cloesce fmt`
+- `"Default"` was not correctly overriding on client crud methods, making users manually specify it.
 
 # [0.3.6] - 2026-4-15
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# [0.3.7] - 2026-4-17
+### Added
+
+### Changed
+
+### Fixed
+- Misc bugs in `cloesce fmt`
+
 # [0.3.6] - 2026-4-15
 ### Added
 - Experimental `cloesce fmt` CLI command

--- a/docs/cidl.js
+++ b/docs/cidl.js
@@ -3,7 +3,7 @@ hljs.registerLanguage("cloesce", function(hljs) {
     // Top-level reserved words (actual lexer keywords)
     const KEYWORDS = [
       "env","model","source","service","inject","api","poo","sql",
-      "d1","r2","kv","vars","self"
+      "d1","r2","kv","vars","self", "internal"
     ];
 
     // Contextual block keywords

--- a/docs/src/ch2-3-data-sources.md
+++ b/docs/src/ch2-3-data-sources.md
@@ -145,7 +145,7 @@ source Custom for Person {
 }
 ```
 
-Every Data Source will be generated to the backend as a type safe query. By default, all Data Sources are exposed to the client for querying. However, should a Data Source be only intended for interal use, it can be marked `internal`:
+Every Data Source will be generated to the backend as a type safe query. By default, all Data Sources are exposed to the client for querying. However, should a Data Source be only intended for internal use, it can be marked `internal`:
 ```cloesce
 
 internal source MyInternal for Person {

--- a/docs/src/ch2-3-data-sources.md
+++ b/docs/src/ch2-3-data-sources.md
@@ -145,11 +145,10 @@ source Custom for Person {
 }
 ```
 
-Every Data Source will be generated to the backend as a type safe query. By default, all Data Sources are exposed to the client for querying. However, should a Data Source be only intended for interal use, it can be marked with the `internal` tag:
+Every Data Source will be generated to the backend as a type safe query. By default, all Data Sources are exposed to the client for querying. However, should a Data Source be only intended for interal use, it can be marked `internal`:
 ```cloesce
 
-[internal]
-source MyInternal for Person {
+internal source MyInternal for Person {
     // ...
 }
 ```

--- a/docs/src/ch2-5-model-methods.md
+++ b/docs/src/ch2-5-model-methods.md
@@ -109,8 +109,7 @@ By default, these methods use the default Data Source for the Model. However, ea
 To hide a Data Source from the client CRUD methods, simply mark the Data Source as `internal`:
 
 ```cloesce
-[internal]
-source Internal for User {
+internal source Internal for User {
     include {
         dogs
     }

--- a/examples/weather/src/schema/schema.clo
+++ b/examples/weather/src/schema/schema.clo
@@ -32,7 +32,6 @@ model Weather {
     foreign (WeatherReport::id) {
         weatherReportId
         
-        // test
         nav {
             weatherReport
         }

--- a/examples/weather/src/schema/schema.clo
+++ b/examples/weather/src/schema/schema.clo
@@ -32,6 +32,7 @@ model Weather {
     foreign (WeatherReport::id) {
         weatherReportId
         
+        // test
         nav {
             weatherReport
         }

--- a/src/compiler/codegen/templates/client.ts.jinja
+++ b/src/compiler/codegen/templates/client.ts.jinja
@@ -110,6 +110,11 @@ export class {{ model.name }} {
   ): Promise<HttpResult<{{ self.map_type(&api.return_type) }}>>;
 {%- endif %}
 {%- endfor %}
+  static $save(
+    model: DeepPartial<{{ model.name }}>,
+    kind?: "Default",
+    fetchImpl?: typeof fetch
+  ): Promise<HttpResult<{{ self.map_type(&api.return_type) }}>>;
   static async $save(
     model: DeepPartial<{{ model.name }}>,
     kind: {{ self.ds_kind_union(&model.data_sources) }} = "Default",
@@ -168,6 +173,11 @@ export class {{ model.name }} {
   ): Promise<HttpResult<{{ self.map_type(&api.return_type) }}>>;
 {%- endif %}
 {%- endfor %}
+  static $get(
+    args: any,
+    kind?: "Default",
+    fetchImpl?: typeof fetch
+  ): Promise<HttpResult<{{ self.map_type(&api.return_type) }}>>;
   static async $get(
     args: any,
     kind: {{ self.ds_kind_union(&model.data_sources) }} = "Default",
@@ -235,6 +245,11 @@ export class {{ model.name }} {
   ): Promise<HttpResult<{{ self.map_type(&api.return_type) }}>>;
 {%- endif %}
 {%- endfor %}
+  static $list(
+    args: any,
+    kind?: "Default",
+    fetchImpl?: typeof fetch
+  ): Promise<HttpResult<{{ self.map_type(&api.return_type) }}>>;
   static async $list(
     args: any,
     kind: {{ self.ds_kind_union(&model.data_sources) }} = "Default",

--- a/src/compiler/codegen/tests/snapshots/client_tests__client_code_generation_snapshot.snap
+++ b/src/compiler/codegen/tests/snapshots/client_tests__client_code_generation_snapshot.snap
@@ -446,6 +446,11 @@ export class ModelWithCruds {
   kind: "Default",
     fetchImpl?: typeof fetch
   ): Promise<HttpResult<ModelWithCruds>>;
+  static $get(
+    args: any,
+    kind?: "Default",
+    fetchImpl?: typeof fetch
+  ): Promise<HttpResult<ModelWithCruds>>;
   static async $get(
     args: any,
     kind: "ByName" | "Default" = "Default",
@@ -478,6 +483,11 @@ export class ModelWithCruds {
   static $save(
     model: DeepPartial<ModelWithCruds>,
     kind: "Default",
+    fetchImpl?: typeof fetch
+  ): Promise<HttpResult<ModelWithCruds>>;
+  static $save(
+    model: DeepPartial<ModelWithCruds>,
+    kind?: "Default",
     fetchImpl?: typeof fetch
   ): Promise<HttpResult<ModelWithCruds>>;
   static async $save(
@@ -519,6 +529,11 @@ export class ModelWithCruds {
       limit: number;
     },
   kind: "Default",
+    fetchImpl?: typeof fetch
+  ): Promise<HttpResult<ModelWithCruds[]>>;
+  static $list(
+    args: any,
+    kind?: "Default",
     fetchImpl?: typeof fetch
   ): Promise<HttpResult<ModelWithCruds[]>>;
   static async $list(

--- a/src/compiler/compiler-test/src/lib.rs
+++ b/src/compiler/compiler-test/src/lib.rs
@@ -27,6 +27,28 @@ macro_rules! expected_str {
     }};
 }
 
+/// Given multiple (path, source) pairs, lex and parse them into a [ParseAst], panicking if either step fails.
+pub fn lex_and_parse_files<'a>(files: &'a [(&'a str, &'a str)]) -> ParseAst<'a> {
+    let sources: Vec<LexTarget<'a>> = files
+        .iter()
+        .map(|(path, src)| LexTarget {
+            src,
+            path: PathBuf::from(path),
+        })
+        .collect();
+    let lexed = CloesceLexer::lex(sources);
+    if lexed.has_errors() {
+        lexed.display_error(&lexed.file_table);
+        panic!("lexing should succeed");
+    }
+    let result = CloesceParser::parse(&lexed.results, &lexed.file_table);
+    if result.has_errors() {
+        result.display_error(&lexed.file_table);
+        panic!("parse should succeed");
+    }
+    result.ast
+}
+
 /// Given a source string, lex and parse it into a [ParseAst], panicking if either step fails.
 pub fn lex_and_parse(src: &str) -> ParseAst<'_> {
     let source = LexTarget {

--- a/src/compiler/frontend/src/formatter/mod.rs
+++ b/src/compiler/frontend/src/formatter/mod.rs
@@ -9,7 +9,7 @@ use crate::{
     DataSourceBlockMethod, EnvBindingBlock, EnvBindingBlockKind, EnvBlock, ForeignBlock,
     ForeignBlockNav, ForeignQualifier, InjectBlock, KvBlock, ModelBlock, ModelBlockKind,
     NavigationBlock, PaginatedBlockKind, ParseAst, ParsedIncludeTree, PlainOldObjectBlock, R2Block,
-    ServiceBlock, Span, Spd, SqlBlockKind, Symbol, UseTag, UseTagParamKind, lexer::CommentMap,
+    ServiceBlock, Spd, SqlBlockKind, Symbol, UseTag, UseTagParamKind, lexer::CommentMap,
 };
 use doc::{Doc, render};
 
@@ -62,10 +62,9 @@ impl<'src> FmtCtx<'src> {
             if offset >= node_start {
                 break;
             }
-            let gap = self.src.get(cursor..offset).unwrap_or("");
-            let newline_count = gap.chars().filter(|&c| c == '\n').count();
+            let gap = self.gap(cursor, offset);
 
-            let extra_blank = if newline_count >= 2 {
+            let extra_blank = if gap >= 2 {
                 Doc::hardline(indent)
             } else {
                 Doc::nil()
@@ -105,11 +104,10 @@ impl<'src> FmtCtx<'src> {
         if let Some(&(offset, text)) = self.cm.entries.get(lo)
             && offset >= node_end
         {
-            let gap = self.src.get(node_end..offset).unwrap_or("");
+            let between = self.src.get(node_end..offset).unwrap_or("");
 
-            // A trailing comment only belongs to this node when there is no
-            // intervening syntax token between the node and the comment.
-            if !gap.contains('\n') && gap.chars().all(char::is_whitespace) {
+            // A trailing comment only belongs to this node when it's on the same line.
+            if !between.contains('\n') && between.chars().all(char::is_whitespace) {
                 self.cursor.set(offset + text.len());
                 return Doc::text(" ").then(Doc::owned(normalize_comment_text(text)));
             }
@@ -139,9 +137,8 @@ impl<'src> FmtCtx<'src> {
                 break;
             }
 
-            let gap = self.src.get(cursor..offset).unwrap_or("");
-            let newline_count = gap.chars().filter(|&c| c == '\n').count();
-            let extra_blank = if newline_count >= 2 {
+            let gap = self.gap(cursor, offset);
+            let extra_blank = if gap >= 2 {
                 Doc::hardline(indent)
             } else {
                 Doc::nil()
@@ -185,13 +182,19 @@ impl<'src> FmtCtx<'src> {
             .then(Doc::text("}"))
     }
 
-    fn gap(&self, span: Span) -> usize {
-        let gap = self.src.get(self.cursor.get()..span.start).unwrap_or("");
-        gap.chars().filter(|&c| c == '\n').count()
+    /// Count the number of newlines in the trailing whitespace of `src[from..to]`.
+    /// Returns >= 2 when there is a blank line immediately before `to`.
+    fn gap(&self, from: usize, to: usize) -> usize {
+        let text = self.src.get(from..to).unwrap_or("");
+        text.chars()
+            .rev()
+            .take_while(|c| c.is_whitespace())
+            .filter(|&c| c == '\n')
+            .count()
     }
 
     fn spd_doc<T: ToDoc<'src>>(&self, spd: &'src Spd<T>, indent: usize, inline: bool) -> Doc<'src> {
-        let gap = self.gap(spd.span);
+        let gap = self.gap(self.cursor.get(), spd.span.start);
         let (leading, has_leading_comments) = self.leading_comments(spd.span.start, indent);
 
         self.node_ends.borrow_mut().push(spd.span.end);
@@ -222,7 +225,7 @@ impl<'src> FmtCtx<'src> {
         }
 
         // Preserve newlines
-        let extra_blank = if indent <= 1 && gap >= 2 && !has_leading_comments {
+        let extra_blank = if gap >= 2 && !has_leading_comments {
             Doc::hardline(indent)
         } else {
             Doc::nil()
@@ -463,9 +466,7 @@ impl<'src> ToDoc<'src> for ForeignBlock<'src> {
         }
 
         if let Some(nav) = &self.nav {
-            inner = inner
-                .then(Doc::hardline(2))
-                .then(ctx.spd_doc(nav, 2, false));
+            inner = inner.then(ctx.spd_doc(nav, 2, false));
         }
 
         doc.then(qualifier).then(ctx.block(inner, 2))

--- a/src/compiler/frontend/src/formatter/mod.rs
+++ b/src/compiler/frontend/src/formatter/mod.rs
@@ -201,17 +201,19 @@ impl<'src> FmtCtx<'src> {
         let trailing = self.trailing_comment(spd.span.end);
         self.advance(spd.span.end);
 
+        let content_sep = if has_leading_comments {
+            Doc::hardline(indent)
+        } else {
+            Doc::nil()
+        };
+
         if inline {
             let leading_sep = if has_leading_comments {
                 Doc::hardline(indent)
             } else {
                 Doc::nil()
             };
-            let content_sep = if has_leading_comments {
-                Doc::hardline(indent)
-            } else {
-                Doc::nil()
-            };
+
             return leading_sep
                 .then(leading)
                 .then(content_sep)
@@ -221,12 +223,6 @@ impl<'src> FmtCtx<'src> {
 
         // Preserve newlines
         let extra_blank = if indent <= 1 && gap >= 2 && !has_leading_comments {
-            Doc::hardline(indent)
-        } else {
-            Doc::nil()
-        };
-
-        let content_sep = if has_leading_comments {
             Doc::hardline(indent)
         } else {
             Doc::nil()
@@ -246,29 +242,25 @@ impl<'src> FmtCtx<'src> {
         let trailing = self.trailing_comment(sym.span.end);
         self.advance(sym.span.end);
 
+        let content_sep = if has_leading_comments {
+            Doc::hardline(indent)
+        } else {
+            Doc::nil()
+        };
+
         if inline {
             let leading_sep = if has_leading_comments {
                 Doc::hardline(indent)
             } else {
                 Doc::nil()
             };
-            let content_sep = if has_leading_comments {
-                Doc::hardline(indent)
-            } else {
-                Doc::nil()
-            };
+
             return leading_sep
                 .then(leading)
                 .then(content_sep)
                 .then(content)
                 .then(trailing);
         }
-
-        let content_sep = if has_leading_comments {
-            Doc::hardline(indent)
-        } else {
-            Doc::nil()
-        };
 
         Doc::hardline(indent)
             .then(leading)
@@ -285,29 +277,25 @@ impl<'src> FmtCtx<'src> {
         let trailing = self.trailing_comment(sym.span.end);
         self.advance(sym.span.end);
 
+        let content_sep = if has_leading_comments {
+            Doc::hardline(indent)
+        } else {
+            Doc::nil()
+        };
+
         if inline {
             let leading_sep = if has_leading_comments {
                 Doc::hardline(indent)
             } else {
                 Doc::nil()
             };
-            let content_sep = if has_leading_comments {
-                Doc::hardline(indent)
-            } else {
-                Doc::nil()
-            };
+
             return leading_sep
                 .then(leading)
                 .then(content_sep)
                 .then(content)
                 .then(trailing);
         }
-
-        let content_sep = if has_leading_comments {
-            Doc::hardline(indent)
-        } else {
-            Doc::nil()
-        };
 
         Doc::hardline(indent)
             .then(leading)
@@ -355,6 +343,7 @@ impl<'src> ToDoc<'src> for AstBlockKind<'src> {
     fn to_doc(&'src self, ctx: &FmtCtx<'src>) -> Doc<'src> {
         match self {
             AstBlockKind::Model(b) => b.to_doc(ctx),
+            AstBlockKind::UseTag(b) => b.to_doc(ctx),
             AstBlockKind::Api(b) => b.to_doc(ctx),
             AstBlockKind::DataSource(b) => b.to_doc(ctx),
             AstBlockKind::Service(b) => b.to_doc(ctx),
@@ -367,19 +356,7 @@ impl<'src> ToDoc<'src> for AstBlockKind<'src> {
 
 impl<'src> ToDoc<'src> for ModelBlock<'src> {
     fn to_doc(&'src self, ctx: &FmtCtx<'src>) -> Doc<'src> {
-        let mut doc = Doc::nil();
-        for tag in &self.use_tags {
-            doc = doc.then(ctx.spd_doc(tag, 0, true)).then(Doc::hardline(0));
-        }
-
-        let (leading, has_leading_comments) = ctx.leading_comments(self.symbol.span.start, 0);
-        if has_leading_comments {
-            doc = doc.then(leading).then(Doc::hardline(0));
-        }
-
-        doc = doc
-            .then(Doc::text("model "))
-            .then(ctx.sym_doc(&self.symbol, 0, true));
+        let doc = Doc::text("model ").then(ctx.sym_doc(&self.symbol, 0, true));
 
         if self.blocks.is_empty() {
             // No content, return empty model
@@ -613,7 +590,7 @@ impl<'src> ToDoc<'src> for DataSourceBlockMethod<'src> {
 impl<'src> ToDoc<'src> for DataSourceBlock<'src> {
     fn to_doc(&'src self, ctx: &FmtCtx<'src>) -> Doc<'src> {
         let internal = if self.is_internal {
-            Doc::text("[internal]").then(Doc::hardline(0))
+            Doc::text("internal ")
         } else {
             Doc::nil()
         };

--- a/src/compiler/frontend/src/lib.rs
+++ b/src/compiler/frontend/src/lib.rs
@@ -261,27 +261,10 @@ pub struct ModelBlock<'src> {
     /// The symbol for the model name, e.g. `ModelName` in `model ModelName { ... }`
     pub symbol: Symbol<'src>,
 
-    pub use_tags: Vec<Spd<UseTag<'src>>>,
     pub blocks: Vec<Spd<ModelBlockKind<'src>>>,
 }
 
 impl<'src> ModelBlock<'src> {
-    pub fn partition_use_tags(&self) -> (Vec<&CrudKind>, Vec<&Symbol<'src>>) {
-        let mut crud_tags = Vec::new();
-        let mut env_binding_tags = Vec::new();
-
-        for tag in &self.use_tags {
-            for param in &tag.block.params {
-                match param {
-                    UseTagParamKind::Crud(spd) => crud_tags.push(&spd.block),
-                    UseTagParamKind::EnvBinding(binding) => env_binding_tags.push(binding),
-                }
-            }
-        }
-
-        (crud_tags, env_binding_tags)
-    }
-
     /// Iterate over all foreign blocks, be they top level or nested in primary/unique/optional blocks
     pub fn foreign_blocks(&self) -> impl Iterator<Item = &ForeignBlock<'src>> {
         self.blocks.iter().flat_map(|spd| match &spd.block {
@@ -364,6 +347,7 @@ pub enum AstBlockKind<'src> {
     Api(ApiBlock<'src>),
     DataSource(DataSourceBlock<'src>),
     Model(ModelBlock<'src>),
+    UseTag(UseTag<'src>),
     Service(ServiceBlock<'src>),
     PlainOldObject(PlainOldObjectBlock<'src>),
     Env(EnvBlock<'src>),

--- a/src/compiler/frontend/src/parser/data_source.rs
+++ b/src/compiler/frontend/src/parser/data_source.rs
@@ -82,14 +82,8 @@ pub fn data_source_block<'tokens, 'src: 'tokens>()
             raw_sql,
         });
 
-    // [internal]
-    let internal_decorator = just(Token::LBracket)
-        .ignore_then(just(Token::Ident("internal")))
-        .then(just(Token::RBracket))
-        .ignored();
-
-    // source SourceName for ModelName { ... }
-    internal_decorator
+    // internal | source SourceName for ModelName { ... }
+    just(Token::Ident("internal"))
         .or_not()
         .then(just(Token::Source).ignore_then(symbol()))
         .then_ignore(just(Token::Ident("for")))

--- a/src/compiler/frontend/src/parser/mod.rs
+++ b/src/compiler/frontend/src/parser/mod.rs
@@ -4,6 +4,7 @@ mod env;
 mod model;
 
 use ast::CidlType;
+use ast::CrudKind;
 use chumsky::extra;
 use chumsky::input::MappedInput;
 use chumsky::prelude::*;
@@ -12,6 +13,8 @@ use crate::AstBlockKind;
 use crate::FileTable;
 use crate::Span;
 use crate::Symbol;
+use crate::UseTag;
+use crate::UseTagParamKind;
 use crate::lexer::LexedFile;
 use crate::lexer::SpannedToken;
 use crate::lexer::Token;
@@ -91,7 +94,8 @@ fn parser<'tokens, 'src: 'tokens>()
 -> impl Parser<'tokens, TokenInput<'tokens, 'src>, ParseAst<'src>, Extra<'tokens, 'src>> {
     choice((
         env::env_block(),
-        model::model_block().map(AstBlockKind::Model),
+        model::model_block(),
+        use_tag_block(),
         api::api_block(),
         data_source::data_source_block(),
         service_block(),
@@ -161,7 +165,7 @@ fn inject_block<'tokens, 'src: 'tokens>()
 ///     ident2: cidl_type
 /// }
 /// ```
-pub fn service_block<'tokens, 'src: 'tokens>()
+fn service_block<'tokens, 'src: 'tokens>()
 -> impl Parser<'tokens, TokenInput<'tokens, 'src>, AstBlockKind<'src>, Extra<'tokens, 'src>> {
     // ident: InjectedService
     let attribute = typed_symbol();
@@ -176,6 +180,34 @@ pub fn service_block<'tokens, 'src: 'tokens>()
                 .delimited_by(just(Token::LBrace), just(Token::RBrace)),
         )
         .map(|(symbol, fields)| AstBlockKind::Service(ServiceBlock { symbol, fields }))
+}
+
+fn use_item<'tokens, 'src: 'tokens>()
+-> impl Parser<'tokens, TokenInput<'tokens, 'src>, UseTagParamKind<'src>, Extra<'tokens, 'src>> {
+    let crud = select! {
+        Token::Ident("get") => CrudKind::Get,
+        Token::Ident("save") => CrudKind::Save,
+        Token::Ident("list") => CrudKind::List,
+    }
+    .map_spanned(|k| k)
+    .map(UseTagParamKind::Crud);
+
+    crud.or(symbol().map(UseTagParamKind::EnvBinding))
+}
+
+fn use_tag_block<'tokens, 'src: 'tokens>()
+-> impl Parser<'tokens, TokenInput<'tokens, 'src>, AstBlockKind<'src>, Extra<'tokens, 'src>> {
+    just(Token::LBracket)
+        .ignore_then(just(Token::Ident("use")))
+        .ignore_then(
+            use_item()
+                .separated_by(just(Token::Comma))
+                .at_least(1)
+                .collect::<Vec<_>>(),
+        )
+        .then_ignore(just(Token::RBracket))
+        .map(|params| UseTag { params })
+        .map(AstBlockKind::UseTag)
 }
 
 /// Parses an identifier and captures its name + span info into a `Symbol`.

--- a/src/compiler/frontend/src/parser/model.rs
+++ b/src/compiler/frontend/src/parser/model.rs
@@ -1,10 +1,8 @@
 use chumsky::prelude::*;
 
-use ast::CrudKind;
-
 use crate::{
-    ForeignBlock, ForeignBlockNav, ForeignQualifier, KvBlock, ModelBlock, ModelBlockKind,
-    NavigationBlock, PaginatedBlockKind, R2Block, Spd, SqlBlockKind, UseTag, UseTagParamKind,
+    AstBlockKind, ForeignBlock, ForeignBlockNav, ForeignQualifier, KvBlock, ModelBlock,
+    ModelBlockKind, NavigationBlock, PaginatedBlockKind, R2Block, Spd, SqlBlockKind,
     lexer::Token,
     parser::{Extra, MapSpanned, TokenInput, symbol, typed_symbol},
 };
@@ -102,33 +100,8 @@ fn r2_block<'tokens, 'src: 'tokens>()
         })
 }
 
-fn use_item<'tokens, 'src: 'tokens>()
--> impl Parser<'tokens, TokenInput<'tokens, 'src>, UseTagParamKind<'src>, Extra<'tokens, 'src>> {
-    let crud = select! {
-        Token::Ident("get") => CrudKind::Get,
-        Token::Ident("save") => CrudKind::Save,
-        Token::Ident("list") => CrudKind::List,
-    }
-    .map_spanned(|k| k)
-    .map(UseTagParamKind::Crud);
-
-    crud.or(symbol().map(UseTagParamKind::EnvBinding))
-}
-
 pub fn model_block<'tokens, 'src: 'tokens>()
--> impl Parser<'tokens, TokenInput<'tokens, 'src>, ModelBlock<'src>, Extra<'tokens, 'src>> {
-    // [use d1, get, save, list]
-    let use_tag = just(Token::LBracket)
-        .ignore_then(just(Token::Ident("use")))
-        .ignore_then(
-            use_item()
-                .separated_by(just(Token::Comma))
-                .at_least(1)
-                .collect::<Vec<_>>(),
-        )
-        .then_ignore(just(Token::RBracket))
-        .map_spanned(|params| UseTag { params });
-
+-> impl Parser<'tokens, TokenInput<'tokens, 'src>, AstBlockKind<'src>, Extra<'tokens, 'src>> {
     let choice_sql = || {
         choice((
             foreign_block().map(SqlBlockKind::Foreign),
@@ -227,11 +200,8 @@ pub fn model_block<'tokens, 'src: 'tokens>()
         unique_block,
     ));
 
-    let use_tags = use_tag.repeated().collect::<Vec<_>>();
-
-    use_tags
-        .then_ignore(just(Token::Model))
-        .then(symbol())
+    just(Token::Model)
+        .ignore_then(symbol())
         .then(
             sub_blocks
                 .map_spanned(|k| k)
@@ -239,11 +209,8 @@ pub fn model_block<'tokens, 'src: 'tokens>()
                 .collect::<Vec<_>>()
                 .delimited_by(just(Token::LBrace), just(Token::RBrace)),
         )
-        .map(|((use_tags, symbol), blocks)| ModelBlock {
-            symbol,
-            use_tags,
-            blocks,
-        })
+        .map(|(symbol, blocks)| ModelBlock { symbol, blocks })
+        .map(AstBlockKind::Model)
         // Without this box, Apple `ld` linker breaks
         // (a symbol name over 1.2 million characters is generated, exceeding the name limit)
         .boxed()

--- a/src/compiler/frontend/tests/parser_tests.rs
+++ b/src/compiler/frontend/tests/parser_tests.rs
@@ -2,7 +2,7 @@ use ast::{CidlType, CrudKind, HttpVerb};
 use compiler_test::lex_and_parse;
 use frontend::{
     AstBlockKind, EnvBindingBlockKind, ForeignBlock, ModelBlock, ModelBlockKind,
-    PaginatedBlockKind, ParseAst, Spd, SqlBlockKind, Symbol, UseTagParamKind,
+    PaginatedBlockKind, ParseAst, Spd, SqlBlockKind, Symbol, UseTag, UseTagParamKind,
 };
 
 fn adj_matches(adj: &[(Symbol, Symbol)], expected: &[(&str, &str)]) -> bool {
@@ -425,11 +425,11 @@ fn model_primary_unique_optional_foreign() {
     );
 
     let m = find_model(&ast, "M");
+    let m_tags = find_use_tags(&ast, "M");
 
-    let env_bindings = m
-        .use_tags
+    let env_bindings = m_tags
         .iter()
-        .flat_map(|t| t.block.params.iter())
+        .flat_map(|t| t.params.iter())
         .filter_map(|p| match p {
             UseTagParamKind::EnvBinding(n) => Some(n.name),
             _ => None,
@@ -437,10 +437,9 @@ fn model_primary_unique_optional_foreign() {
         .collect::<Vec<_>>();
     assert_eq!(env_bindings, vec!["d1_db", "d2_db"]);
 
-    let cruds: Vec<CrudKind> = m
-        .use_tags
+    let cruds: Vec<CrudKind> = m_tags
         .iter()
-        .flat_map(|t| t.block.params.iter())
+        .flat_map(|t| t.params.iter())
         .filter_map(|p| match p {
             UseTagParamKind::Crud(c) => Some(c.block.clone()),
             _ => None,
@@ -782,11 +781,11 @@ fn model_kv_r2_paginated() {
     );
 
     let kv_model = find_model(&ast, "PureKv");
+    let kv_tags = find_use_tags(&ast, "PureKv");
 
-    let kv_env_bindings = kv_model
-        .use_tags
+    let kv_env_bindings = kv_tags
         .iter()
-        .flat_map(|t| t.block.params.iter())
+        .flat_map(|t| t.params.iter())
         .filter_map(|p| match p {
             UseTagParamKind::EnvBinding(n) => Some(n),
             _ => None,
@@ -794,10 +793,9 @@ fn model_kv_r2_paginated() {
         .collect::<Vec<_>>();
     assert!(kv_env_bindings.is_empty());
 
-    let kv_cruds: Vec<CrudKind> = kv_model
-        .use_tags
+    let kv_cruds: Vec<CrudKind> = kv_tags
         .iter()
-        .flat_map(|t| t.block.params.iter())
+        .flat_map(|t| t.params.iter())
         .filter_map(|p| match p {
             UseTagParamKind::Crud(c) => Some(c.block.clone()),
             _ => None,
@@ -868,4 +866,25 @@ fn find_model<'a>(ast: &'a ParseAst<'a>, name: &str) -> &'a ModelBlock<'a> {
             _ => None,
         })
         .unwrap_or_else(|| panic!("{name} model to be present"))
+}
+
+fn find_use_tags<'a>(ast: &'a ParseAst<'a>, model_name: &str) -> Vec<&'a UseTag<'a>> {
+    let model_pos = ast
+        .blocks
+        .iter()
+        .position(|spd| matches!(&spd.block, AstBlockKind::Model(m) if m.symbol.name == model_name))
+        .unwrap_or_else(|| panic!("{model_name} model to be present"));
+
+    ast.blocks[..model_pos]
+        .iter()
+        .rev()
+        .take_while(|spd| matches!(&spd.block, AstBlockKind::UseTag(_)))
+        .map(|spd| match &spd.block {
+            AstBlockKind::UseTag(t) => t,
+            _ => unreachable!(),
+        })
+        .collect::<Vec<_>>()
+        .into_iter()
+        .rev()
+        .collect()
 }

--- a/src/compiler/frontend/tests/snapshots/formatter_tests__comments_retained.snap
+++ b/src/compiler/frontend/tests/snapshots/formatter_tests__comments_retained.snap
@@ -28,7 +28,6 @@ model BasicModel {
     foreign (OneToManyModel::id) {
         // E
         fk_to_model // 15
-        
         // 16
         nav {
             // F

--- a/src/compiler/frontend/tests/snapshots/formatter_tests__format_non_lossy.snap
+++ b/src/compiler/frontend/tests/snapshots/formatter_tests__format_non_lossy.snap
@@ -63,7 +63,6 @@ model HasOneToOne {
     
     foreign (BasicModel::id) {
         basicModelId
-        
         nav {
             oneToOneNav
         }
@@ -237,7 +236,6 @@ model ModelWithCustomDs {
     
     foreign (OneToManyModel::id) {
         oneToManyId
-        
         nav {
             oneToManyModel
         }

--- a/src/compiler/semantic/src/err.rs
+++ b/src/compiler/semantic/src/err.rs
@@ -183,6 +183,11 @@ pub enum SemanticError<'src, 'p> {
     ApiReservedMethod {
         method: &'p Symbol<'src>,
     },
+
+    /// A use tag is not immediately followed by a model block.
+    OrphanUseTag {
+        span: Span,
+    },
 }
 
 #[derive(Debug, Default)]
@@ -875,6 +880,20 @@ fn display(
                         .with_message(
                             "names like `$get`, `$list`, and `$save` are reserved by the compiler",
                         )
+                        .with_color(Color::Red),
+                )
+                .finish()
+                .write(cache, std::io::stderr())
+                .ok();
+        }
+
+        SemanticError::OrphanUseTag { span } => {
+            let (path, range) = span_parts(span, file_table);
+            Report::build(ariadne::ReportKind::Error, (path.clone(), range.clone()))
+                .with_message("use tag is not followed by a model block")
+                .with_label(
+                    Label::new((path, range))
+                        .with_message("this use tag must be placed immediately before a model")
                         .with_color(Color::Red),
                 )
                 .finish()

--- a/src/compiler/semantic/src/lib.rs
+++ b/src/compiler/semantic/src/lib.rs
@@ -2,11 +2,14 @@ use ast::{CidlType, CloesceAst, Field, PlainOldObject, Service, WranglerEnv};
 use frontend::{
     ApiBlock, ApiBlockMethodParamKind, AstBlockKind, DataSourceBlock, EnvBindingBlockKind,
     EnvBlock, InjectBlock, ModelBlock, ParseAst, PlainOldObjectBlock, ServiceBlock, SpdSlice,
-    Symbol,
+    Symbol, UseTag,
 };
 use indexmap::IndexMap;
 
-use std::collections::{BTreeMap, HashMap, VecDeque};
+use std::{
+    collections::{BTreeMap, HashMap, VecDeque},
+    ops::Not,
+};
 
 use crate::{
     api::ApiAnalysis,
@@ -23,14 +26,14 @@ pub mod err;
 mod model;
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq, Ord, PartialOrd)]
-pub enum EnvBindingKind {
+enum EnvBindingKind {
     D1,
     R2,
     Kv,
 }
 
 #[derive(Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub enum SymbolKind<'src> {
+enum SymbolKind<'src> {
     // Scoped
     EnvVar(&'src str),
     EnvBinding {
@@ -72,8 +75,9 @@ pub enum SymbolKind<'src> {
 type SymbolLookup<'src, 'p> = BTreeMap<SymbolKind<'src>, &'p Symbol<'src>>;
 
 #[derive(Default)]
-pub struct SymbolTable<'src, 'p> {
+struct SymbolTable<'src, 'p> {
     models: BTreeMap<&'src str, &'p ModelBlock<'src>>,
+    model_use_tags: BTreeMap<&'src str, Vec<&'p UseTag<'src>>>,
     poos: BTreeMap<&'src str, &'p PlainOldObjectBlock<'src>>,
     services: BTreeMap<&'src str, &'p ServiceBlock<'src>>,
     envs: Vec<&'p EnvBlock<'src>>,
@@ -106,15 +110,35 @@ impl<'src, 'p> SymbolTable<'src, 'p> {
             }
         };
 
-        for block in parse.blocks.blocks() {
-            match block {
+        let mut pending_use_tags = Vec::new();
+
+        for spd in &parse.blocks {
+            if matches!(spd.block, AstBlockKind::Model(_)).not()
+                && matches!(spd.block, AstBlockKind::UseTag(_)).not()
+            {
+                for (_, span) in pending_use_tags.drain(..) {
+                    sink.push(SemanticError::OrphanUseTag { span });
+                }
+            }
+
+            match &spd.block {
+                AstBlockKind::UseTag(tag) => {
+                    pending_use_tags.push((tag, spd.span));
+                }
                 AstBlockKind::Model(model_block) => {
+                    let tags = std::mem::take(&mut pending_use_tags);
+                    if !tags.is_empty() {
+                        st.model_use_tags.insert(
+                            model_block.symbol.name,
+                            tags.into_iter().map(|(t, _)| t).collect(),
+                        );
+                    }
+
                     insert_global(sink, &model_block.symbol);
                     st.models.insert(model_block.symbol.name, model_block);
 
                     for sub_block in model_block.blocks.blocks() {
-                        let symbols = sub_block.symbols();
-                        for symbol in symbols {
+                        for symbol in sub_block.symbols() {
                             if let Some(first) = st.model_fields.insert(
                                 SymbolKind::ModelField {
                                     model: model_block.symbol.name,

--- a/src/compiler/semantic/src/lib.rs
+++ b/src/compiler/semantic/src/lib.rs
@@ -110,11 +110,20 @@ impl<'src, 'p> SymbolTable<'src, 'p> {
             }
         };
 
-        let mut pending_use_tags = Vec::new();
+        // Use tags are top level but must be attached to some model
+        // Defer their insertion until a model is encountered, or orphan them if a
+        // non-model block or new file is encountered
+        let mut pending_use_tags = Vec::<(&'p UseTag<'src>, frontend::Span)>::new();
 
         for spd in &parse.blocks {
+            let is_new_file = spd.span.start
+                < pending_use_tags
+                    .last()
+                    .map(|(_, span): &(_, _)| span.start)
+                    .unwrap_or(0);
             if matches!(spd.block, AstBlockKind::Model(_)).not()
                 && matches!(spd.block, AstBlockKind::UseTag(_)).not()
+                || is_new_file
             {
                 for (_, span) in pending_use_tags.drain(..) {
                     sink.push(SemanticError::OrphanUseTag { span });
@@ -333,6 +342,10 @@ impl<'src, 'p> SymbolTable<'src, 'p> {
                     }
                 }
             }
+        }
+
+        for (_, span) in pending_use_tags.drain(..) {
+            sink.push(SemanticError::OrphanUseTag { span });
         }
 
         st

--- a/src/compiler/semantic/src/model.rs
+++ b/src/compiler/semantic/src/model.rs
@@ -374,7 +374,10 @@ impl<'src, 'p> ModelBuilder<'src, 'p> {
         }
 
         // Must belong to the same database
-        let adj_binding = partition_use_tags(adj_model_block.symbol.name, table).1.into_iter().next();
+        let adj_binding = partition_use_tags(adj_model_block.symbol.name, table)
+            .1
+            .into_iter()
+            .next();
         if adj_binding.map(|s| s.name) != Some(binding_symbol.name) {
             ma.sink
                 .push(SemanticError::ForeignKeyReferencesDifferentDatabase {
@@ -530,7 +533,10 @@ impl<'src, 'p> ModelBuilder<'src, 'p> {
         let adj_model_block = table.models.get(adj.first().unwrap().0.name).unwrap();
 
         // Must belong to the same database
-        let adj_binding = partition_use_tags(adj_model_block.symbol.name, table).1.into_iter().next();
+        let adj_binding = partition_use_tags(adj_model_block.symbol.name, table)
+            .1
+            .into_iter()
+            .next();
         if adj_binding.map(|s| s.name) != Some(binding_symbol.name) {
             ma.sink
                 .push(SemanticError::NavigationReferencesDifferentDatabase { field });
@@ -808,7 +814,12 @@ fn partition_use_tags<'src, 'p>(
 ) -> (Vec<&'p CrudKind>, Vec<&'p Symbol<'src>>) {
     let mut cruds = Vec::new();
     let mut env_bindings = Vec::new();
-    for tag in table.model_use_tags.get(model_name).map(|v| v.as_slice()).unwrap_or(&[]) {
+    for tag in table
+        .model_use_tags
+        .get(model_name)
+        .map(|v| v.as_slice())
+        .unwrap_or(&[])
+    {
         for param in &tag.params {
             match param {
                 UseTagParamKind::Crud(spd) => cruds.push(&spd.block),

--- a/src/compiler/semantic/src/model.rs
+++ b/src/compiler/semantic/src/model.rs
@@ -10,7 +10,7 @@ use ast::{
 };
 use frontend::{
     ForeignBlock, ForeignQualifier, KvBlock, ModelBlock, ModelBlockKind, PaginatedBlockKind,
-    R2Block, SpdSlice, SqlBlockKind, Symbol,
+    R2Block, SpdSlice, SqlBlockKind, Symbol, UseTagParamKind,
 };
 use indexmap::IndexMap;
 use std::{collections::BTreeMap, vec};
@@ -30,7 +30,7 @@ impl<'src, 'p> ModelAnalysis<'src, 'p> {
         let mut models: IndexMap<&'src str, Model<'src>> = IndexMap::new();
 
         for &model_block in table.models.values() {
-            let (cruds, env_bindings) = model_block.partition_use_tags();
+            let (cruds, env_bindings) = partition_use_tags(model_block.symbol.name, table);
 
             let builder = ModelBuilder::new(model_block);
             let Some(mut model) = builder.build(&mut self, env_bindings, table) else {
@@ -374,7 +374,7 @@ impl<'src, 'p> ModelBuilder<'src, 'p> {
         }
 
         // Must belong to the same database
-        let adj_binding = adj_model_block.partition_use_tags().1.first().copied();
+        let adj_binding = partition_use_tags(adj_model_block.symbol.name, table).1.into_iter().next();
         if adj_binding.map(|s| s.name) != Some(binding_symbol.name) {
             ma.sink
                 .push(SemanticError::ForeignKeyReferencesDifferentDatabase {
@@ -530,7 +530,7 @@ impl<'src, 'p> ModelBuilder<'src, 'p> {
         let adj_model_block = table.models.get(adj.first().unwrap().0.name).unwrap();
 
         // Must belong to the same database
-        let adj_binding = adj_model_block.partition_use_tags().1.first().copied();
+        let adj_binding = partition_use_tags(adj_model_block.symbol.name, table).1.into_iter().next();
         if adj_binding.map(|s| s.name) != Some(binding_symbol.name) {
             ma.sink
                 .push(SemanticError::NavigationReferencesDifferentDatabase { field });
@@ -800,6 +800,23 @@ struct FieldQualifiers {
     is_optional: bool,
     is_primary: bool,
     unique_ids: Vec<usize>,
+}
+
+fn partition_use_tags<'src, 'p>(
+    model_name: &'src str,
+    table: &SymbolTable<'src, 'p>,
+) -> (Vec<&'p CrudKind>, Vec<&'p Symbol<'src>>) {
+    let mut cruds = Vec::new();
+    let mut env_bindings = Vec::new();
+    for tag in table.model_use_tags.get(model_name).map(|v| v.as_slice()).unwrap_or(&[]) {
+        for param in &tag.params {
+            match param {
+                UseTagParamKind::Crud(spd) => cruds.push(&spd.block),
+                UseTagParamKind::EnvBinding(sym) => env_bindings.push(sym),
+            }
+        }
+    }
+    (cruds, env_bindings)
 }
 
 /// Extracts braced variables from a format string.

--- a/src/compiler/semantic/tests/analysis_tests.rs
+++ b/src/compiler/semantic/tests/analysis_tests.rs
@@ -1,7 +1,7 @@
 #![allow(unused_variables)]
 
 use ast::{CidlType, Field, MediaType, NavigationFieldKind};
-use compiler_test::lex_and_parse;
+use compiler_test::{lex_and_parse, lex_and_parse_files};
 use semantic::{SemanticAnalysis, err::SemanticError};
 
 /// Find exactly one error matching the pattern. Panics if not found.
@@ -47,6 +47,43 @@ fn with_env(src: &str) -> String {
     "#,
         src
     )
+}
+
+#[test]
+fn orphan_use_tag() {
+    // Arrange
+    let file_a = r#"
+        env {
+            d1 { my_d1 }
+        }
+
+        [use my_d1]
+        model GoodModel {
+            primary { id: int }
+        }
+
+        [use my_d1]
+        env {
+            kv { my_kv }
+        }
+
+        [use my_d1]
+    "#;
+
+    let file_b = r#"
+        model ShouldNotInheritTag {
+            primary { id: int }
+        }
+    "#;
+
+    let files = [("a.cidl", file_a), ("b.cidl", file_b)];
+
+    // Act
+    let parse = lex_and_parse_files(&files);
+    let (_, errors) = SemanticAnalysis::analyze(&parse);
+
+    // Assert
+    assert_eq!(count_errs!(errors, SemanticError::OrphanUseTag { .. }), 2);
 }
 
 #[test]

--- a/tests/e2e/fixtures/adv_ds/client.ts
+++ b/tests/e2e/fixtures/adv_ds/client.ts
@@ -56,6 +56,11 @@ export class Hamburger {
     kind: "Default",
     fetchImpl?: typeof fetch
   ): Promise<HttpResult<Hamburger>>;
+  static $save(
+    model: DeepPartial<Hamburger>,
+    kind?: "Default",
+    fetchImpl?: typeof fetch
+  ): Promise<HttpResult<Hamburger>>;
   static async $save(
     model: DeepPartial<Hamburger>,
     kind: "BurgersWithLettuceOrdered" | "Default" = "Default",
@@ -86,7 +91,7 @@ export class Hamburger {
       lastId: number;
       limit: number;
     },
-  kind: "BurgersWithLettuceOrdered",
+    kind: "BurgersWithLettuceOrdered",
     fetchImpl?: typeof fetch
   ): Promise<HttpResult<Hamburger[]>>;
   static $list(
@@ -94,7 +99,12 @@ export class Hamburger {
       lastSeen_id: number;
       limit: number;
     },
-  kind: "Default",
+    kind: "Default",
+    fetchImpl?: typeof fetch
+  ): Promise<HttpResult<Hamburger[]>>;
+  static $list(
+    args: any,
+    kind?: "Default",
     fetchImpl?: typeof fetch
   ): Promise<HttpResult<Hamburger[]>>;
   static async $list(
@@ -106,9 +116,9 @@ export class Hamburger {
       `http://localhost:5403/api/Hamburger/$list`
     );
     const payload: any = {};
-  baseUrl.searchParams.append("lastId", String((args as any).lastId ?? null));
-  baseUrl.searchParams.append("limit", String((args as any).limit ?? null));
-  baseUrl.searchParams.append("lastSeen_id", String((args as any).lastSeen_id ?? null));
+    baseUrl.searchParams.append("lastId", String((args as any).lastId ?? null));
+    baseUrl.searchParams.append("limit", String((args as any).limit ?? null));
+    baseUrl.searchParams.append("lastSeen_id", String((args as any).lastSeen_id ?? null));
     baseUrl.searchParams.append("__datasource", kind);
 
     const res = await fetchImpl(baseUrl, {
@@ -138,6 +148,11 @@ export class Topping {
   static $save(
     model: DeepPartial<Topping>,
     kind: "Default",
+    fetchImpl?: typeof fetch
+  ): Promise<HttpResult<Topping>>;
+  static $save(
+    model: DeepPartial<Topping>,
+    kind?: "Default",
     fetchImpl?: typeof fetch
   ): Promise<HttpResult<Topping>>;
   static async $save(

--- a/tests/e2e/fixtures/adv_ds/schema.cloesce
+++ b/tests/e2e/fixtures/adv_ds/schema.cloesce
@@ -47,8 +47,7 @@ source BurgersWithLettuceOrdered for Hamburger {
     }
 }
 
-[internal]
-source NoLettuce for Hamburger {
+internal source NoLettuce for Hamburger {
     include {
         toppings
     }
@@ -64,8 +63,7 @@ source NoLettuce for Hamburger {
     }
 }
 
-[internal]
-source OnlyBacon for Hamburger {
+internal source OnlyBacon for Hamburger {
     include {
         toppings
     }

--- a/tests/e2e/fixtures/blobs/client.ts
+++ b/tests/e2e/fixtures/blobs/client.ts
@@ -97,6 +97,11 @@ export class BlobHaver {
     kind: "Default",
     fetchImpl?: typeof fetch
   ): Promise<HttpResult<BlobHaver>>;
+  static $save(
+    model: DeepPartial<BlobHaver>,
+    kind?: "Default",
+    fetchImpl?: typeof fetch
+  ): Promise<HttpResult<BlobHaver>>;
   static async $save(
     model: DeepPartial<BlobHaver>,
     kind: "Default" = "Default",
@@ -129,6 +134,11 @@ export class BlobHaver {
   kind: "Default",
     fetchImpl?: typeof fetch
   ): Promise<HttpResult<BlobHaver>>;
+  static $get(
+    args: any,
+    kind?: "Default",
+    fetchImpl?: typeof fetch
+  ): Promise<HttpResult<BlobHaver>>;
   static async $get(
     args: any,
     kind: "Default" = "Default",
@@ -158,6 +168,11 @@ export class BlobHaver {
       limit: number;
     },
   kind: "Default",
+    fetchImpl?: typeof fetch
+  ): Promise<HttpResult<BlobHaver[]>>;
+  static $list(
+    args: any,
+    kind?: "Default",
     fetchImpl?: typeof fetch
   ): Promise<HttpResult<BlobHaver[]>>;
   static async $list(

--- a/tests/e2e/fixtures/bools_dates_ints/client.ts
+++ b/tests/e2e/fixtures/bools_dates_ints/client.ts
@@ -9,6 +9,11 @@ export class Weather {
     kind: "Default",
     fetchImpl?: typeof fetch
   ): Promise<HttpResult<Weather>>;
+  static $save(
+    model: DeepPartial<Weather>,
+    kind?: "Default",
+    fetchImpl?: typeof fetch
+  ): Promise<HttpResult<Weather>>;
   static async $save(
     model: DeepPartial<Weather>,
     kind: "Default" = "Default",
@@ -39,6 +44,11 @@ export class Weather {
       id: number;
     },
   kind: "Default",
+    fetchImpl?: typeof fetch
+  ): Promise<HttpResult<Weather>>;
+  static $get(
+    args: any,
+    kind?: "Default",
     fetchImpl?: typeof fetch
   ): Promise<HttpResult<Weather>>;
   static async $get(

--- a/tests/e2e/fixtures/composite_keys/client.ts
+++ b/tests/e2e/fixtures/composite_keys/client.ts
@@ -11,6 +11,11 @@ export class Course {
   kind: "Default",
     fetchImpl?: typeof fetch
   ): Promise<HttpResult<Course>>;
+  static $get(
+    args: any,
+    kind?: "Default",
+    fetchImpl?: typeof fetch
+  ): Promise<HttpResult<Course>>;
   static async $get(
     args: any,
     kind: "Default" = "Default",
@@ -42,6 +47,11 @@ export class Course {
   kind: "Default",
     fetchImpl?: typeof fetch
   ): Promise<HttpResult<Course[]>>;
+  static $list(
+    args: any,
+    kind?: "Default",
+    fetchImpl?: typeof fetch
+  ): Promise<HttpResult<Course[]>>;
   static async $list(
     args: any,
     kind: "Default" = "Default",
@@ -69,6 +79,11 @@ export class Course {
   static $save(
     model: DeepPartial<Course>,
     kind: "Default",
+    fetchImpl?: typeof fetch
+  ): Promise<HttpResult<Course>>;
+  static $save(
+    model: DeepPartial<Course>,
+    kind?: "Default",
     fetchImpl?: typeof fetch
   ): Promise<HttpResult<Course>>;
   static async $save(
@@ -126,6 +141,11 @@ export class Student {
   kind: "Default",
     fetchImpl?: typeof fetch
   ): Promise<HttpResult<Student>>;
+  static $get(
+    args: any,
+    kind?: "Default",
+    fetchImpl?: typeof fetch
+  ): Promise<HttpResult<Student>>;
   static async $get(
     args: any,
     kind: "CoursesOrderedDescending" | "Default" = "Default",
@@ -168,6 +188,11 @@ export class Student {
   kind: "Default",
     fetchImpl?: typeof fetch
   ): Promise<HttpResult<Student[]>>;
+  static $list(
+    args: any,
+    kind?: "Default",
+    fetchImpl?: typeof fetch
+  ): Promise<HttpResult<Student[]>>;
   static async $list(
     args: any,
     kind: "CoursesOrderedDescending" | "Default" = "Default",
@@ -203,6 +228,11 @@ export class Student {
   static $save(
     model: DeepPartial<Student>,
     kind: "Default",
+    fetchImpl?: typeof fetch
+  ): Promise<HttpResult<Student>>;
+  static $save(
+    model: DeepPartial<Student>,
+    kind?: "Default",
     fetchImpl?: typeof fetch
   ): Promise<HttpResult<Student>>;
   static async $save(
@@ -263,6 +293,11 @@ export class StudentCourse {
   kind: "WithStudentCourse",
     fetchImpl?: typeof fetch
   ): Promise<HttpResult<StudentCourse>>;
+  static $get(
+    args: any,
+    kind?: "Default",
+    fetchImpl?: typeof fetch
+  ): Promise<HttpResult<StudentCourse>>;
   static async $get(
     args: any,
     kind: "Default" | "WithStudentCourse" = "Default",
@@ -308,6 +343,11 @@ export class StudentCourse {
   kind: "WithStudentCourse",
     fetchImpl?: typeof fetch
   ): Promise<HttpResult<StudentCourse[]>>;
+  static $list(
+    args: any,
+    kind?: "Default",
+    fetchImpl?: typeof fetch
+  ): Promise<HttpResult<StudentCourse[]>>;
   static async $list(
     args: any,
     kind: "Default" | "WithStudentCourse" = "Default",
@@ -342,6 +382,11 @@ export class StudentCourse {
   static $save(
     model: DeepPartial<StudentCourse>,
     kind: "WithStudentCourse",
+    fetchImpl?: typeof fetch
+  ): Promise<HttpResult<StudentCourse>>;
+  static $save(
+    model: DeepPartial<StudentCourse>,
+    kind?: "Default",
     fetchImpl?: typeof fetch
   ): Promise<HttpResult<StudentCourse>>;
   static async $save(

--- a/tests/e2e/fixtures/d1_crud/client.ts
+++ b/tests/e2e/fixtures/d1_crud/client.ts
@@ -32,6 +32,11 @@ export class CrudHaver {
     kind: "Default",
     fetchImpl?: typeof fetch
   ): Promise<HttpResult<CrudHaver>>;
+  static $save(
+    model: DeepPartial<CrudHaver>,
+    kind?: "Default",
+    fetchImpl?: typeof fetch
+  ): Promise<HttpResult<CrudHaver>>;
   static async $save(
     model: DeepPartial<CrudHaver>,
     kind: "Default" = "Default",
@@ -64,6 +69,11 @@ export class CrudHaver {
   kind: "Default",
     fetchImpl?: typeof fetch
   ): Promise<HttpResult<CrudHaver>>;
+  static $get(
+    args: any,
+    kind?: "Default",
+    fetchImpl?: typeof fetch
+  ): Promise<HttpResult<CrudHaver>>;
   static async $get(
     args: any,
     kind: "Default" = "Default",
@@ -93,6 +103,11 @@ export class CrudHaver {
       limit: number;
     },
   kind: "Default",
+    fetchImpl?: typeof fetch
+  ): Promise<HttpResult<CrudHaver[]>>;
+  static $list(
+    args: any,
+    kind?: "Default",
     fetchImpl?: typeof fetch
   ): Promise<HttpResult<CrudHaver[]>>;
   static async $list(
@@ -140,6 +155,11 @@ export class Parent {
     kind: "WithChildren",
     fetchImpl?: typeof fetch
   ): Promise<HttpResult<Parent>>;
+  static $save(
+    model: DeepPartial<Parent>,
+    kind?: "Default",
+    fetchImpl?: typeof fetch
+  ): Promise<HttpResult<Parent>>;
   static async $save(
     model: DeepPartial<Parent>,
     kind: "Default" | "WithChildren" = "Default",
@@ -179,6 +199,11 @@ export class Parent {
   kind: "WithChildren",
     fetchImpl?: typeof fetch
   ): Promise<HttpResult<Parent>>;
+  static $get(
+    args: any,
+    kind?: "Default",
+    fetchImpl?: typeof fetch
+  ): Promise<HttpResult<Parent>>;
   static async $get(
     args: any,
     kind: "Default" | "WithChildren" = "Default",
@@ -216,6 +241,11 @@ export class Parent {
       limit: number;
     },
   kind: "WithChildren",
+    fetchImpl?: typeof fetch
+  ): Promise<HttpResult<Parent[]>>;
+  static $list(
+    args: any,
+    kind?: "Default",
     fetchImpl?: typeof fetch
   ): Promise<HttpResult<Parent[]>>;
   static async $list(

--- a/tests/e2e/fixtures/foreign_keys/client.ts
+++ b/tests/e2e/fixtures/foreign_keys/client.ts
@@ -63,6 +63,11 @@ export class A {
     kind: "WithoutB",
     fetchImpl?: typeof fetch
   ): Promise<HttpResult<A>>;
+  static $save(
+    model: DeepPartial<A>,
+    kind?: "Default",
+    fetchImpl?: typeof fetch
+  ): Promise<HttpResult<A>>;
   static async $save(
     model: DeepPartial<A>,
     kind: "Default" | "WithB" | "WithoutB" = "Default",
@@ -107,6 +112,11 @@ export class A {
       id: number;
     },
   kind: "WithoutB",
+    fetchImpl?: typeof fetch
+  ): Promise<HttpResult<A>>;
+  static $get(
+    args: any,
+    kind?: "Default",
     fetchImpl?: typeof fetch
   ): Promise<HttpResult<A>>;
   static async $get(
@@ -171,6 +181,11 @@ export class B {
     kind: "Default",
     fetchImpl?: typeof fetch
   ): Promise<HttpResult<B>>;
+  static $save(
+    model: DeepPartial<B>,
+    kind?: "Default",
+    fetchImpl?: typeof fetch
+  ): Promise<HttpResult<B>>;
   static async $save(
     model: DeepPartial<B>,
     kind: "Default" = "Default",
@@ -201,6 +216,11 @@ export class B {
       id: number;
     },
   kind: "Default",
+    fetchImpl?: typeof fetch
+  ): Promise<HttpResult<B>>;
+  static $get(
+    args: any,
+    kind?: "Default",
     fetchImpl?: typeof fetch
   ): Promise<HttpResult<B>>;
   static async $get(
@@ -241,6 +261,11 @@ export class Course {
   static $save(
     model: DeepPartial<Course>,
     kind: "Default",
+    fetchImpl?: typeof fetch
+  ): Promise<HttpResult<Course>>;
+  static $save(
+    model: DeepPartial<Course>,
+    kind?: "Default",
     fetchImpl?: typeof fetch
   ): Promise<HttpResult<Course>>;
   static async $save(
@@ -339,6 +364,11 @@ export class Person {
     kind: "WithoutDogs",
     fetchImpl?: typeof fetch
   ): Promise<HttpResult<Person>>;
+  static $save(
+    model: DeepPartial<Person>,
+    kind?: "Default",
+    fetchImpl?: typeof fetch
+  ): Promise<HttpResult<Person>>;
   static async $save(
     model: DeepPartial<Person>,
     kind: "Default" | "WithDogs" | "WithoutDogs" = "Default",
@@ -383,6 +413,11 @@ export class Person {
       id: number;
     },
   kind: "WithoutDogs",
+    fetchImpl?: typeof fetch
+  ): Promise<HttpResult<Person>>;
+  static $get(
+    args: any,
+    kind?: "Default",
     fetchImpl?: typeof fetch
   ): Promise<HttpResult<Person>>;
   static async $get(
@@ -479,6 +514,11 @@ export class Student {
     kind: "WithCoursesStudentsCourses",
     fetchImpl?: typeof fetch
   ): Promise<HttpResult<Student>>;
+  static $save(
+    model: DeepPartial<Student>,
+    kind?: "Default",
+    fetchImpl?: typeof fetch
+  ): Promise<HttpResult<Student>>;
   static async $save(
     model: DeepPartial<Student>,
     kind: "Default" | "None" | "WithCoursesStudentsCourses" = "Default",
@@ -523,6 +563,11 @@ export class Student {
       id: number;
     },
   kind: "WithCoursesStudentsCourses",
+    fetchImpl?: typeof fetch
+  ): Promise<HttpResult<Student>>;
+  static $get(
+    args: any,
+    kind?: "Default",
     fetchImpl?: typeof fetch
   ): Promise<HttpResult<Student>>;
   static async $get(
@@ -588,6 +633,11 @@ export class Dog {
   static $save(
     model: DeepPartial<Dog>,
     kind: "Default",
+    fetchImpl?: typeof fetch
+  ): Promise<HttpResult<Dog>>;
+  static $save(
+    model: DeepPartial<Dog>,
+    kind?: "Default",
     fetchImpl?: typeof fetch
   ): Promise<HttpResult<Dog>>;
   static async $save(

--- a/tests/e2e/fixtures/kv/client.ts
+++ b/tests/e2e/fixtures/kv/client.ts
@@ -14,6 +14,11 @@ export class D1BackedModel {
   kind: "Default",
     fetchImpl?: typeof fetch
   ): Promise<HttpResult<D1BackedModel>>;
+  static $get(
+    args: any,
+    kind?: "Default",
+    fetchImpl?: typeof fetch
+  ): Promise<HttpResult<D1BackedModel>>;
   static async $get(
     args: any,
     kind: "Default" = "Default",
@@ -41,6 +46,11 @@ export class D1BackedModel {
   static $save(
     model: DeepPartial<D1BackedModel>,
     kind: "Default",
+    fetchImpl?: typeof fetch
+  ): Promise<HttpResult<D1BackedModel>>;
+  static $save(
+    model: DeepPartial<D1BackedModel>,
+    kind?: "Default",
     fetchImpl?: typeof fetch
   ): Promise<HttpResult<D1BackedModel>>;
   static async $save(
@@ -74,6 +84,11 @@ export class D1BackedModel {
       limit: number;
     },
   kind: "Default",
+    fetchImpl?: typeof fetch
+  ): Promise<HttpResult<D1BackedModel[]>>;
+  static $list(
+    args: any,
+    kind?: "Default",
     fetchImpl?: typeof fetch
   ): Promise<HttpResult<D1BackedModel[]>>;
   static async $list(
@@ -140,6 +155,11 @@ export class PaginatedKVModel {
   kind: "Default",
     fetchImpl?: typeof fetch
   ): Promise<HttpResult<PaginatedKVModel>>;
+  static $get(
+    args: any,
+    kind?: "Default",
+    fetchImpl?: typeof fetch
+  ): Promise<HttpResult<PaginatedKVModel>>;
   static async $get(
     args: any,
     kind: "Default" = "Default",
@@ -185,6 +205,11 @@ export class PureKVModel {
   kind: "Default",
     fetchImpl?: typeof fetch
   ): Promise<HttpResult<PureKVModel>>;
+  static $get(
+    args: any,
+    kind?: "Default",
+    fetchImpl?: typeof fetch
+  ): Promise<HttpResult<PureKVModel>>;
   static async $get(
     args: any,
     kind: "Default" = "Default",
@@ -211,6 +236,11 @@ export class PureKVModel {
   static $save(
     model: DeepPartial<PureKVModel>,
     kind: "Default",
+    fetchImpl?: typeof fetch
+  ): Promise<HttpResult<PureKVModel>>;
+  static $save(
+    model: DeepPartial<PureKVModel>,
+    kind?: "Default",
     fetchImpl?: typeof fetch
   ): Promise<HttpResult<PureKVModel>>;
   static async $save(

--- a/tests/e2e/fixtures/middleware/client.ts
+++ b/tests/e2e/fixtures/middleware/client.ts
@@ -43,6 +43,11 @@ export class Foo {
     kind: "Default",
     fetchImpl?: typeof fetch
   ): Promise<HttpResult<Foo>>;
+  static $save(
+    model: DeepPartial<Foo>,
+    kind?: "Default",
+    fetchImpl?: typeof fetch
+  ): Promise<HttpResult<Foo>>;
   static async $save(
     model: DeepPartial<Foo>,
     kind: "Default" = "Default",

--- a/tests/e2e/fixtures/multiple_db/client.ts
+++ b/tests/e2e/fixtures/multiple_db/client.ts
@@ -10,6 +10,11 @@ export class DB1Model {
   kind: "Default",
     fetchImpl?: typeof fetch
   ): Promise<HttpResult<DB1Model>>;
+  static $get(
+    args: any,
+    kind?: "Default",
+    fetchImpl?: typeof fetch
+  ): Promise<HttpResult<DB1Model>>;
   static async $get(
     args: any,
     kind: "Default" = "Default",
@@ -36,6 +41,11 @@ export class DB1Model {
   static $save(
     model: DeepPartial<DB1Model>,
     kind: "Default",
+    fetchImpl?: typeof fetch
+  ): Promise<HttpResult<DB1Model>>;
+  static $save(
+    model: DeepPartial<DB1Model>,
+    kind?: "Default",
     fetchImpl?: typeof fetch
   ): Promise<HttpResult<DB1Model>>;
   static async $save(
@@ -69,6 +79,11 @@ export class DB1Model {
       limit: number;
     },
   kind: "Default",
+    fetchImpl?: typeof fetch
+  ): Promise<HttpResult<DB1Model[]>>;
+  static $list(
+    args: any,
+    kind?: "Default",
     fetchImpl?: typeof fetch
   ): Promise<HttpResult<DB1Model[]>>;
   static async $list(
@@ -111,6 +126,11 @@ export class DB2Model {
   kind: "Default",
     fetchImpl?: typeof fetch
   ): Promise<HttpResult<DB2Model>>;
+  static $get(
+    args: any,
+    kind?: "Default",
+    fetchImpl?: typeof fetch
+  ): Promise<HttpResult<DB2Model>>;
   static async $get(
     args: any,
     kind: "Default" = "Default",
@@ -137,6 +157,11 @@ export class DB2Model {
   static $save(
     model: DeepPartial<DB2Model>,
     kind: "Default",
+    fetchImpl?: typeof fetch
+  ): Promise<HttpResult<DB2Model>>;
+  static $save(
+    model: DeepPartial<DB2Model>,
+    kind?: "Default",
     fetchImpl?: typeof fetch
   ): Promise<HttpResult<DB2Model>>;
   static async $save(
@@ -170,6 +195,11 @@ export class DB2Model {
       limit: number;
     },
   kind: "Default",
+    fetchImpl?: typeof fetch
+  ): Promise<HttpResult<DB2Model[]>>;
+  static $list(
+    args: any,
+    kind?: "Default",
     fetchImpl?: typeof fetch
   ): Promise<HttpResult<DB2Model[]>>;
   static async $list(

--- a/tests/e2e/fixtures/partials/client.ts
+++ b/tests/e2e/fixtures/partials/client.ts
@@ -53,6 +53,11 @@ export class Dog {
     kind: "Default",
     fetchImpl?: typeof fetch
   ): Promise<HttpResult<Dog>>;
+  static $save(
+    model: DeepPartial<Dog>,
+    kind?: "Default",
+    fetchImpl?: typeof fetch
+  ): Promise<HttpResult<Dog>>;
   static async $save(
     model: DeepPartial<Dog>,
     kind: "Default" = "Default",

--- a/tests/e2e/fixtures/r2/client.ts
+++ b/tests/e2e/fixtures/r2/client.ts
@@ -41,6 +41,11 @@ export class D1BackedModel {
   kind: "Default",
     fetchImpl?: typeof fetch
   ): Promise<HttpResult<D1BackedModel>>;
+  static $get(
+    args: any,
+    kind?: "Default",
+    fetchImpl?: typeof fetch
+  ): Promise<HttpResult<D1BackedModel>>;
   static async $get(
     args: any,
     kind: "Default" = "Default",
@@ -68,6 +73,11 @@ export class D1BackedModel {
   static $save(
     model: DeepPartial<D1BackedModel>,
     kind: "Default",
+    fetchImpl?: typeof fetch
+  ): Promise<HttpResult<D1BackedModel>>;
+  static $save(
+    model: DeepPartial<D1BackedModel>,
+    kind?: "Default",
     fetchImpl?: typeof fetch
   ): Promise<HttpResult<D1BackedModel>>;
   static async $save(
@@ -101,6 +111,11 @@ export class D1BackedModel {
       limit: number;
     },
   kind: "Default",
+    fetchImpl?: typeof fetch
+  ): Promise<HttpResult<D1BackedModel[]>>;
+  static $list(
+    args: any,
+    kind?: "Default",
     fetchImpl?: typeof fetch
   ): Promise<HttpResult<D1BackedModel[]>>;
   static async $list(
@@ -195,6 +210,11 @@ export class PureR2Model {
       id: string;
     },
   kind: "Default",
+    fetchImpl?: typeof fetch
+  ): Promise<HttpResult<PureR2Model>>;
+  static $get(
+    args: any,
+    kind?: "Default",
     fetchImpl?: typeof fetch
   ): Promise<HttpResult<PureR2Model>>;
   static async $get(


### PR DESCRIPTION
Fixed a couple of spots where the formatter would leave double spaces.

Promoted the `UseTag` ParseAST node to it's own top level block to fix some spanning issues (tag was spanned with the model itself, so  putting comments in between made things weird)

Additionally, promoted `[internal]` to a keyword `internal` for data sources, ex:
```
internal source MySource for Foo {...}
```

Finally, fixed a bug where the default data source wasn't automatically applied in the client and had to be manually specified