### PR TITLE
fix: `impl` return type widening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# [0.3.9] - 2026-4-19
+### Added
+
+### Changed
+
+### Fixed
+- A bug where the `impl` function would widen the return type to `ApiResult` instead of inferring the specific return type of the method, making it difficult to work with the results without manually type asserting.
+
 # [0.3.8] - 2026-4-17
 ### Added
 

--- a/src/compiler/codegen/templates/backend.ts.jinja
+++ b/src/compiler/codegen/templates/backend.ts.jinja
@@ -110,7 +110,7 @@ export namespace {{ model.name }} {
     }
     export const _api = undefined as unknown as Api;
 
-    export function impl<Impl extends Api>(implObj: Impl & ThisType<Impl & typeof Source & { tag: string; Key: {% if model.kv_fields.is_empty() && model.r2_fields.is_empty() %}any{% else %}typeof Key{% endif %}; Orm: typeof Orm }>): Impl & typeof Source & { tag: string; Key: {% if model.kv_fields.is_empty() && model.r2_fields.is_empty() %}any{% else %}typeof Key{% endif %}; Orm: typeof Orm } {
+    export function impl<Impl extends Api>(implObj: Impl & ThisType<typeof Source & { tag: string; Key: {% if model.kv_fields.is_empty() && model.r2_fields.is_empty() %}any{% else %}typeof Key{% endif %}; Orm: typeof Orm }>): typeof Source & { tag: string; Key: {% if model.kv_fields.is_empty() && model.r2_fields.is_empty() %}any{% else %}typeof Key{% endif %}; Orm: typeof Orm } & Impl {
         return _impl({{ model.name }}, implObj);
     }
 {%- if !model.data_sources.is_empty() %}
@@ -170,7 +170,7 @@ export namespace {{ model.name }} {
 }
 {%- endfor %}
 
-function _impl<NS extends { Kind: "model"; Meta: { name: string }; Source: any; _api: any; Orm: any; Key?: any }, Impl extends NS["_api"]>(namespace: NS, implObj: Impl & ThisType<Impl & NS["Source"] & { tag: string; Key: NS["Key"]; Orm: NS["Orm"] }>): Impl & NS["Source"] & { tag: string; Key: NS["Key"]; Orm: NS["Orm"] };
+function _impl<NS extends { Kind: "model"; Meta: { name: string }; Source: any; _api: any; Orm: any; Key?: any }, Impl extends NS["_api"]>(namespace: NS, implObj: Impl & ThisType<NS["Source"] & { tag: string; Key: NS["Key"]; Orm: NS["Orm"] }>): NS["Source"] & { tag: string; Key: NS["Key"]; Orm: NS["Orm"] } & Impl;
 function _impl<NS extends { Kind: "service"; Tag: string; _api: any }, Impl extends NS["_api"]>(namespace: NS, implObj: Impl): Impl & { tag: NS["Tag"] };
 function _impl(namespace: any, implObj: any) {
     if (namespace.Kind === "model") {

--- a/src/compiler/codegen/tests/snapshots/backend_tests__backend_code_generation_snapshot.snap
+++ b/src/compiler/codegen/tests/snapshots/backend_tests__backend_code_generation_snapshot.snap
@@ -73,7 +73,7 @@ export namespace HasSqlColumnTypes {
     }
     export const _api = undefined as unknown as Api;
 
-    export function impl<Impl extends Api>(implObj: Impl & ThisType<Impl & typeof Source & { tag: string; Key: any; Orm: typeof Orm }>): Impl & typeof Source & { tag: string; Key: any; Orm: typeof Orm } {
+    export function impl<Impl extends Api>(implObj: Impl & ThisType<typeof Source & { tag: string; Key: any; Orm: typeof Orm }>): typeof Source & { tag: string; Key: any; Orm: typeof Orm } & Impl {
         return _impl(HasSqlColumnTypes, implObj);
     }
 
@@ -136,7 +136,7 @@ export namespace ManyToManyModelA {
     }
     export const _api = undefined as unknown as Api;
 
-    export function impl<Impl extends Api>(implObj: Impl & ThisType<Impl & typeof Source & { tag: string; Key: any; Orm: typeof Orm }>): Impl & typeof Source & { tag: string; Key: any; Orm: typeof Orm } {
+    export function impl<Impl extends Api>(implObj: Impl & ThisType<typeof Source & { tag: string; Key: any; Orm: typeof Orm }>): typeof Source & { tag: string; Key: any; Orm: typeof Orm } & Impl {
         return _impl(ManyToManyModelA, implObj);
     }
 
@@ -199,7 +199,7 @@ export namespace ManyToManyModelB {
     }
     export const _api = undefined as unknown as Api;
 
-    export function impl<Impl extends Api>(implObj: Impl & ThisType<Impl & typeof Source & { tag: string; Key: any; Orm: typeof Orm }>): Impl & typeof Source & { tag: string; Key: any; Orm: typeof Orm } {
+    export function impl<Impl extends Api>(implObj: Impl & ThisType<typeof Source & { tag: string; Key: any; Orm: typeof Orm }>): typeof Source & { tag: string; Key: any; Orm: typeof Orm } & Impl {
         return _impl(ManyToManyModelB, implObj);
     }
 
@@ -264,7 +264,7 @@ export namespace ModelWithCompositePk {
     }
     export const _api = undefined as unknown as Api;
 
-    export function impl<Impl extends Api>(implObj: Impl & ThisType<Impl & typeof Source & { tag: string; Key: any; Orm: typeof Orm }>): Impl & typeof Source & { tag: string; Key: any; Orm: typeof Orm } {
+    export function impl<Impl extends Api>(implObj: Impl & ThisType<typeof Source & { tag: string; Key: any; Orm: typeof Orm }>): typeof Source & { tag: string; Key: any; Orm: typeof Orm } & Impl {
         return _impl(ModelWithCompositePk, implObj);
     }
 
@@ -342,7 +342,7 @@ export namespace ModelWithKv {
     }
     export const _api = undefined as unknown as Api;
 
-    export function impl<Impl extends Api>(implObj: Impl & ThisType<Impl & typeof Source & { tag: string; Key: typeof Key; Orm: typeof Orm }>): Impl & typeof Source & { tag: string; Key: typeof Key; Orm: typeof Orm } {
+    export function impl<Impl extends Api>(implObj: Impl & ThisType<typeof Source & { tag: string; Key: typeof Key; Orm: typeof Orm }>): typeof Source & { tag: string; Key: typeof Key; Orm: typeof Orm } & Impl {
         return _impl(ModelWithKv, implObj);
     }
 
@@ -408,7 +408,7 @@ export namespace ModelWithR2 {
     }
     export const _api = undefined as unknown as Api;
 
-    export function impl<Impl extends Api>(implObj: Impl & ThisType<Impl & typeof Source & { tag: string; Key: typeof Key; Orm: typeof Orm }>): Impl & typeof Source & { tag: string; Key: typeof Key; Orm: typeof Orm } {
+    export function impl<Impl extends Api>(implObj: Impl & ThisType<typeof Source & { tag: string; Key: typeof Key; Orm: typeof Orm }>): typeof Source & { tag: string; Key: typeof Key; Orm: typeof Orm } & Impl {
         return _impl(ModelWithR2, implObj);
     }
 
@@ -466,7 +466,7 @@ export namespace OneToManyModel {
     }
     export const _api = undefined as unknown as Api;
 
-    export function impl<Impl extends Api>(implObj: Impl & ThisType<Impl & typeof Source & { tag: string; Key: any; Orm: typeof Orm }>): Impl & typeof Source & { tag: string; Key: any; Orm: typeof Orm } {
+    export function impl<Impl extends Api>(implObj: Impl & ThisType<typeof Source & { tag: string; Key: any; Orm: typeof Orm }>): typeof Source & { tag: string; Key: any; Orm: typeof Orm } & Impl {
         return _impl(OneToManyModel, implObj);
     }
 
@@ -540,7 +540,7 @@ export namespace ToyotaPrius {
     }
     export const _api = undefined as unknown as Api;
 
-    export function impl<Impl extends Api>(implObj: Impl & ThisType<Impl & typeof Source & { tag: string; Key: typeof Key; Orm: typeof Orm }>): Impl & typeof Source & { tag: string; Key: typeof Key; Orm: typeof Orm } {
+    export function impl<Impl extends Api>(implObj: Impl & ThisType<typeof Source & { tag: string; Key: typeof Key; Orm: typeof Orm }>): typeof Source & { tag: string; Key: typeof Key; Orm: typeof Orm } & Impl {
         return _impl(ToyotaPrius, implObj);
     }
 
@@ -625,7 +625,7 @@ export namespace BasicModel {
     }
     export const _api = undefined as unknown as Api;
 
-    export function impl<Impl extends Api>(implObj: Impl & ThisType<Impl & typeof Source & { tag: string; Key: any; Orm: typeof Orm }>): Impl & typeof Source & { tag: string; Key: any; Orm: typeof Orm } {
+    export function impl<Impl extends Api>(implObj: Impl & ThisType<typeof Source & { tag: string; Key: any; Orm: typeof Orm }>): typeof Source & { tag: string; Key: any; Orm: typeof Orm } & Impl {
         return _impl(BasicModel, implObj);
     }
 
@@ -695,7 +695,7 @@ export namespace ModelWithCustomDs {
     }
     export const _api = undefined as unknown as Api;
 
-    export function impl<Impl extends Api>(implObj: Impl & ThisType<Impl & typeof Source & { tag: string; Key: typeof Key; Orm: typeof Orm }>): Impl & typeof Source & { tag: string; Key: typeof Key; Orm: typeof Orm } {
+    export function impl<Impl extends Api>(implObj: Impl & ThisType<typeof Source & { tag: string; Key: typeof Key; Orm: typeof Orm }>): typeof Source & { tag: string; Key: typeof Key; Orm: typeof Orm } & Impl {
         return _impl(ModelWithCustomDs, implObj);
     }
 
@@ -770,7 +770,7 @@ export namespace HasOneToOne {
     }
     export const _api = undefined as unknown as Api;
 
-    export function impl<Impl extends Api>(implObj: Impl & ThisType<Impl & typeof Source & { tag: string; Key: any; Orm: typeof Orm }>): Impl & typeof Source & { tag: string; Key: any; Orm: typeof Orm } {
+    export function impl<Impl extends Api>(implObj: Impl & ThisType<typeof Source & { tag: string; Key: any; Orm: typeof Orm }>): typeof Source & { tag: string; Key: any; Orm: typeof Orm } & Impl {
         return _impl(HasOneToOne, implObj);
     }
 
@@ -834,7 +834,7 @@ export namespace ModelWithCruds {
     }
     export const _api = undefined as unknown as Api;
 
-    export function impl<Impl extends Api>(implObj: Impl & ThisType<Impl & typeof Source & { tag: string; Key: any; Orm: typeof Orm }>): Impl & typeof Source & { tag: string; Key: any; Orm: typeof Orm } {
+    export function impl<Impl extends Api>(implObj: Impl & ThisType<typeof Source & { tag: string; Key: any; Orm: typeof Orm }>): typeof Source & { tag: string; Key: any; Orm: typeof Orm } & Impl {
         return _impl(ModelWithCruds, implObj);
     }
 
@@ -892,7 +892,7 @@ export namespace ModelWithCruds {
     }
 }
 
-function _impl<NS extends { Kind: "model"; Meta: { name: string }; Source: any; _api: any; Orm: any; Key?: any }, Impl extends NS["_api"]>(namespace: NS, implObj: Impl & ThisType<Impl & NS["Source"] & { tag: string; Key: NS["Key"]; Orm: NS["Orm"] }>): Impl & NS["Source"] & { tag: string; Key: NS["Key"]; Orm: NS["Orm"] };
+function _impl<NS extends { Kind: "model"; Meta: { name: string }; Source: any; _api: any; Orm: any; Key?: any }, Impl extends NS["_api"]>(namespace: NS, implObj: Impl & ThisType<NS["Source"] & { tag: string; Key: NS["Key"]; Orm: NS["Orm"] }>): NS["Source"] & { tag: string; Key: NS["Key"]; Orm: NS["Orm"] } & Impl;
 function _impl<NS extends { Kind: "service"; Tag: string; _api: any }, Impl extends NS["_api"]>(namespace: NS, implObj: Impl): Impl & { tag: NS["Tag"] };
 function _impl(namespace: any, implObj: any) {
     if (namespace.Kind === "model") {

--- a/tests/e2e/fixtures/adv_ds/backend.ts
+++ b/tests/e2e/fixtures/adv_ds/backend.ts
@@ -29,7 +29,7 @@ export namespace Hamburger {
     }
     export const _api = undefined as unknown as Api;
 
-    export function impl<Impl extends Api>(implObj: Impl & ThisType<Impl & typeof Source & { tag: string; Key: any; Orm: typeof Orm }>): Impl & typeof Source & { tag: string; Key: any; Orm: typeof Orm } {
+    export function impl<Impl extends Api>(implObj: Impl & ThisType<typeof Source & { tag: string; Key: any; Orm: typeof Orm }>): typeof Source & { tag: string; Key: any; Orm: typeof Orm } & Impl {
         return _impl(Hamburger, implObj);
     }
 
@@ -126,7 +126,7 @@ export namespace Topping {
     }
     export const _api = undefined as unknown as Api;
 
-    export function impl<Impl extends Api>(implObj: Impl & ThisType<Impl & typeof Source & { tag: string; Key: any; Orm: typeof Orm }>): Impl & typeof Source & { tag: string; Key: any; Orm: typeof Orm } {
+    export function impl<Impl extends Api>(implObj: Impl & ThisType<typeof Source & { tag: string; Key: any; Orm: typeof Orm }>): typeof Source & { tag: string; Key: any; Orm: typeof Orm } & Impl {
         return _impl(Topping, implObj);
     }
 
@@ -173,7 +173,7 @@ export namespace Topping {
     }
 }
 
-function _impl<NS extends { Kind: "model"; Meta: { name: string }; Source: any; _api: any; Orm: any; Key?: any }, Impl extends NS["_api"]>(namespace: NS, implObj: Impl & ThisType<Impl & NS["Source"] & { tag: string; Key: NS["Key"]; Orm: NS["Orm"] }>): Impl & NS["Source"] & { tag: string; Key: NS["Key"]; Orm: NS["Orm"] };
+function _impl<NS extends { Kind: "model"; Meta: { name: string }; Source: any; _api: any; Orm: any; Key?: any }, Impl extends NS["_api"]>(namespace: NS, implObj: Impl & ThisType<NS["Source"] & { tag: string; Key: NS["Key"]; Orm: NS["Orm"] }>): NS["Source"] & { tag: string; Key: NS["Key"]; Orm: NS["Orm"] } & Impl;
 function _impl<NS extends { Kind: "service"; Tag: string; _api: any }, Impl extends NS["_api"]>(namespace: NS, implObj: Impl): Impl & { tag: NS["Tag"] };
 function _impl(namespace: any, implObj: any) {
     if (namespace.Kind === "model") {

--- a/tests/e2e/fixtures/blobs/backend.ts
+++ b/tests/e2e/fixtures/blobs/backend.ts
@@ -47,7 +47,7 @@ export namespace BlobHaver {
     }
     export const _api = undefined as unknown as Api;
 
-    export function impl<Impl extends Api>(implObj: Impl & ThisType<Impl & typeof Source & { tag: string; Key: any; Orm: typeof Orm }>): Impl & typeof Source & { tag: string; Key: any; Orm: typeof Orm } {
+    export function impl<Impl extends Api>(implObj: Impl & ThisType<typeof Source & { tag: string; Key: any; Orm: typeof Orm }>): typeof Source & { tag: string; Key: any; Orm: typeof Orm } & Impl {
         return _impl(BlobHaver, implObj);
     }
 
@@ -94,7 +94,7 @@ export namespace BlobHaver {
     }
 }
 
-function _impl<NS extends { Kind: "model"; Meta: { name: string }; Source: any; _api: any; Orm: any; Key?: any }, Impl extends NS["_api"]>(namespace: NS, implObj: Impl & ThisType<Impl & NS["Source"] & { tag: string; Key: NS["Key"]; Orm: NS["Orm"] }>): Impl & NS["Source"] & { tag: string; Key: NS["Key"]; Orm: NS["Orm"] };
+function _impl<NS extends { Kind: "model"; Meta: { name: string }; Source: any; _api: any; Orm: any; Key?: any }, Impl extends NS["_api"]>(namespace: NS, implObj: Impl & ThisType<NS["Source"] & { tag: string; Key: NS["Key"]; Orm: NS["Orm"] }>): NS["Source"] & { tag: string; Key: NS["Key"]; Orm: NS["Orm"] } & Impl;
 function _impl<NS extends { Kind: "service"; Tag: string; _api: any }, Impl extends NS["_api"]>(namespace: NS, implObj: Impl): Impl & { tag: NS["Tag"] };
 function _impl(namespace: any, implObj: any) {
     if (namespace.Kind === "model") {

--- a/tests/e2e/fixtures/bools_dates_ints/backend.ts
+++ b/tests/e2e/fixtures/bools_dates_ints/backend.ts
@@ -27,7 +27,7 @@ export namespace Weather {
     }
     export const _api = undefined as unknown as Api;
 
-    export function impl<Impl extends Api>(implObj: Impl & ThisType<Impl & typeof Source & { tag: string; Key: any; Orm: typeof Orm }>): Impl & typeof Source & { tag: string; Key: any; Orm: typeof Orm } {
+    export function impl<Impl extends Api>(implObj: Impl & ThisType<typeof Source & { tag: string; Key: any; Orm: typeof Orm }>): typeof Source & { tag: string; Key: any; Orm: typeof Orm } & Impl {
         return _impl(Weather, implObj);
     }
 
@@ -74,7 +74,7 @@ export namespace Weather {
     }
 }
 
-function _impl<NS extends { Kind: "model"; Meta: { name: string }; Source: any; _api: any; Orm: any; Key?: any }, Impl extends NS["_api"]>(namespace: NS, implObj: Impl & ThisType<Impl & NS["Source"] & { tag: string; Key: NS["Key"]; Orm: NS["Orm"] }>): Impl & NS["Source"] & { tag: string; Key: NS["Key"]; Orm: NS["Orm"] };
+function _impl<NS extends { Kind: "model"; Meta: { name: string }; Source: any; _api: any; Orm: any; Key?: any }, Impl extends NS["_api"]>(namespace: NS, implObj: Impl & ThisType<NS["Source"] & { tag: string; Key: NS["Key"]; Orm: NS["Orm"] }>): NS["Source"] & { tag: string; Key: NS["Key"]; Orm: NS["Orm"] } & Impl;
 function _impl<NS extends { Kind: "service"; Tag: string; _api: any }, Impl extends NS["_api"]>(namespace: NS, implObj: Impl): Impl & { tag: NS["Tag"] };
 function _impl(namespace: any, implObj: any) {
     if (namespace.Kind === "model") {

--- a/tests/e2e/fixtures/composite_keys/backend.ts
+++ b/tests/e2e/fixtures/composite_keys/backend.ts
@@ -27,7 +27,7 @@ export namespace Course {
     }
     export const _api = undefined as unknown as Api;
 
-    export function impl<Impl extends Api>(implObj: Impl & ThisType<Impl & typeof Source & { tag: string; Key: any; Orm: typeof Orm }>): Impl & typeof Source & { tag: string; Key: any; Orm: typeof Orm } {
+    export function impl<Impl extends Api>(implObj: Impl & ThisType<typeof Source & { tag: string; Key: any; Orm: typeof Orm }>): typeof Source & { tag: string; Key: any; Orm: typeof Orm } & Impl {
         return _impl(Course, implObj);
     }
 
@@ -92,7 +92,7 @@ export namespace Student {
     }
     export const _api = undefined as unknown as Api;
 
-    export function impl<Impl extends Api>(implObj: Impl & ThisType<Impl & typeof Source & { tag: string; Key: any; Orm: typeof Orm }>): Impl & typeof Source & { tag: string; Key: any; Orm: typeof Orm } {
+    export function impl<Impl extends Api>(implObj: Impl & ThisType<typeof Source & { tag: string; Key: any; Orm: typeof Orm }>): typeof Source & { tag: string; Key: any; Orm: typeof Orm } & Impl {
         return _impl(Student, implObj);
     }
 
@@ -169,7 +169,7 @@ export namespace StudentCourse {
     }
     export const _api = undefined as unknown as Api;
 
-    export function impl<Impl extends Api>(implObj: Impl & ThisType<Impl & typeof Source & { tag: string; Key: any; Orm: typeof Orm }>): Impl & typeof Source & { tag: string; Key: any; Orm: typeof Orm } {
+    export function impl<Impl extends Api>(implObj: Impl & ThisType<typeof Source & { tag: string; Key: any; Orm: typeof Orm }>): typeof Source & { tag: string; Key: any; Orm: typeof Orm } & Impl {
         return _impl(StudentCourse, implObj);
     }
 
@@ -227,7 +227,7 @@ export namespace StudentCourse {
     }
 }
 
-function _impl<NS extends { Kind: "model"; Meta: { name: string }; Source: any; _api: any; Orm: any; Key?: any }, Impl extends NS["_api"]>(namespace: NS, implObj: Impl & ThisType<Impl & NS["Source"] & { tag: string; Key: NS["Key"]; Orm: NS["Orm"] }>): Impl & NS["Source"] & { tag: string; Key: NS["Key"]; Orm: NS["Orm"] };
+function _impl<NS extends { Kind: "model"; Meta: { name: string }; Source: any; _api: any; Orm: any; Key?: any }, Impl extends NS["_api"]>(namespace: NS, implObj: Impl & ThisType<NS["Source"] & { tag: string; Key: NS["Key"]; Orm: NS["Orm"] }>): NS["Source"] & { tag: string; Key: NS["Key"]; Orm: NS["Orm"] } & Impl;
 function _impl<NS extends { Kind: "service"; Tag: string; _api: any }, Impl extends NS["_api"]>(namespace: NS, implObj: Impl): Impl & { tag: NS["Tag"] };
 function _impl(namespace: any, implObj: any) {
     if (namespace.Kind === "model") {

--- a/tests/e2e/fixtures/d1_crud/backend.ts
+++ b/tests/e2e/fixtures/d1_crud/backend.ts
@@ -27,7 +27,7 @@ export namespace CrudHaver {
     }
     export const _api = undefined as unknown as Api;
 
-    export function impl<Impl extends Api>(implObj: Impl & ThisType<Impl & typeof Source & { tag: string; Key: any; Orm: typeof Orm }>): Impl & typeof Source & { tag: string; Key: any; Orm: typeof Orm } {
+    export function impl<Impl extends Api>(implObj: Impl & ThisType<typeof Source & { tag: string; Key: any; Orm: typeof Orm }>): typeof Source & { tag: string; Key: any; Orm: typeof Orm } & Impl {
         return _impl(CrudHaver, implObj);
     }
 
@@ -92,7 +92,7 @@ export namespace Parent {
     }
     export const _api = undefined as unknown as Api;
 
-    export function impl<Impl extends Api>(implObj: Impl & ThisType<Impl & typeof Source & { tag: string; Key: any; Orm: typeof Orm }>): Impl & typeof Source & { tag: string; Key: any; Orm: typeof Orm } {
+    export function impl<Impl extends Api>(implObj: Impl & ThisType<typeof Source & { tag: string; Key: any; Orm: typeof Orm }>): typeof Source & { tag: string; Key: any; Orm: typeof Orm } & Impl {
         return _impl(Parent, implObj);
     }
 
@@ -167,7 +167,7 @@ export namespace Child {
     }
     export const _api = undefined as unknown as Api;
 
-    export function impl<Impl extends Api>(implObj: Impl & ThisType<Impl & typeof Source & { tag: string; Key: any; Orm: typeof Orm }>): Impl & typeof Source & { tag: string; Key: any; Orm: typeof Orm } {
+    export function impl<Impl extends Api>(implObj: Impl & ThisType<typeof Source & { tag: string; Key: any; Orm: typeof Orm }>): typeof Source & { tag: string; Key: any; Orm: typeof Orm } & Impl {
         return _impl(Child, implObj);
     }
 
@@ -214,7 +214,7 @@ export namespace Child {
     }
 }
 
-function _impl<NS extends { Kind: "model"; Meta: { name: string }; Source: any; _api: any; Orm: any; Key?: any }, Impl extends NS["_api"]>(namespace: NS, implObj: Impl & ThisType<Impl & NS["Source"] & { tag: string; Key: NS["Key"]; Orm: NS["Orm"] }>): Impl & NS["Source"] & { tag: string; Key: NS["Key"]; Orm: NS["Orm"] };
+function _impl<NS extends { Kind: "model"; Meta: { name: string }; Source: any; _api: any; Orm: any; Key?: any }, Impl extends NS["_api"]>(namespace: NS, implObj: Impl & ThisType<NS["Source"] & { tag: string; Key: NS["Key"]; Orm: NS["Orm"] }>): NS["Source"] & { tag: string; Key: NS["Key"]; Orm: NS["Orm"] } & Impl;
 function _impl<NS extends { Kind: "service"; Tag: string; _api: any }, Impl extends NS["_api"]>(namespace: NS, implObj: Impl): Impl & { tag: NS["Tag"] };
 function _impl(namespace: any, implObj: any) {
     if (namespace.Kind === "model") {

--- a/tests/e2e/fixtures/data_source_type/backend.ts
+++ b/tests/e2e/fixtures/data_source_type/backend.ts
@@ -29,7 +29,7 @@ export namespace Foo {
     }
     export const _api = undefined as unknown as Api;
 
-    export function impl<Impl extends Api>(implObj: Impl & ThisType<Impl & typeof Source & { tag: string; Key: any; Orm: typeof Orm }>): Impl & typeof Source & { tag: string; Key: any; Orm: typeof Orm } {
+    export function impl<Impl extends Api>(implObj: Impl & ThisType<typeof Source & { tag: string; Key: any; Orm: typeof Orm }>): typeof Source & { tag: string; Key: any; Orm: typeof Orm } & Impl {
         return _impl(Foo, implObj);
     }
 
@@ -102,7 +102,7 @@ export namespace NoDs {
     }
     export const _api = undefined as unknown as Api;
 
-    export function impl<Impl extends Api>(implObj: Impl & ThisType<Impl & typeof Source & { tag: string; Key: any; Orm: typeof Orm }>): Impl & typeof Source & { tag: string; Key: any; Orm: typeof Orm } {
+    export function impl<Impl extends Api>(implObj: Impl & ThisType<typeof Source & { tag: string; Key: any; Orm: typeof Orm }>): typeof Source & { tag: string; Key: any; Orm: typeof Orm } & Impl {
         return _impl(NoDs, implObj);
     }
 
@@ -164,7 +164,7 @@ export namespace OneDs {
     }
     export const _api = undefined as unknown as Api;
 
-    export function impl<Impl extends Api>(implObj: Impl & ThisType<Impl & typeof Source & { tag: string; Key: any; Orm: typeof Orm }>): Impl & typeof Source & { tag: string; Key: any; Orm: typeof Orm } {
+    export function impl<Impl extends Api>(implObj: Impl & ThisType<typeof Source & { tag: string; Key: any; Orm: typeof Orm }>): typeof Source & { tag: string; Key: any; Orm: typeof Orm } & Impl {
         return _impl(OneDs, implObj);
     }
 
@@ -222,7 +222,7 @@ export namespace OneDs {
     }
 }
 
-function _impl<NS extends { Kind: "model"; Meta: { name: string }; Source: any; _api: any; Orm: any; Key?: any }, Impl extends NS["_api"]>(namespace: NS, implObj: Impl & ThisType<Impl & NS["Source"] & { tag: string; Key: NS["Key"]; Orm: NS["Orm"] }>): Impl & NS["Source"] & { tag: string; Key: NS["Key"]; Orm: NS["Orm"] };
+function _impl<NS extends { Kind: "model"; Meta: { name: string }; Source: any; _api: any; Orm: any; Key?: any }, Impl extends NS["_api"]>(namespace: NS, implObj: Impl & ThisType<NS["Source"] & { tag: string; Key: NS["Key"]; Orm: NS["Orm"] }>): NS["Source"] & { tag: string; Key: NS["Key"]; Orm: NS["Orm"] } & Impl;
 function _impl<NS extends { Kind: "service"; Tag: string; _api: any }, Impl extends NS["_api"]>(namespace: NS, implObj: Impl): Impl & { tag: NS["Tag"] };
 function _impl(namespace: any, implObj: any) {
     if (namespace.Kind === "model") {

--- a/tests/e2e/fixtures/foreign_keys/backend.ts
+++ b/tests/e2e/fixtures/foreign_keys/backend.ts
@@ -29,7 +29,7 @@ export namespace A {
     }
     export const _api = undefined as unknown as Api;
 
-    export function impl<Impl extends Api>(implObj: Impl & ThisType<Impl & typeof Source & { tag: string; Key: any; Orm: typeof Orm }>): Impl & typeof Source & { tag: string; Key: any; Orm: typeof Orm } {
+    export function impl<Impl extends Api>(implObj: Impl & ThisType<typeof Source & { tag: string; Key: any; Orm: typeof Orm }>): typeof Source & { tag: string; Key: any; Orm: typeof Orm } & Impl {
         return _impl(A, implObj);
     }
 
@@ -115,7 +115,7 @@ export namespace B {
     }
     export const _api = undefined as unknown as Api;
 
-    export function impl<Impl extends Api>(implObj: Impl & ThisType<Impl & typeof Source & { tag: string; Key: any; Orm: typeof Orm }>): Impl & typeof Source & { tag: string; Key: any; Orm: typeof Orm } {
+    export function impl<Impl extends Api>(implObj: Impl & ThisType<typeof Source & { tag: string; Key: any; Orm: typeof Orm }>): typeof Source & { tag: string; Key: any; Orm: typeof Orm } & Impl {
         return _impl(B, implObj);
     }
 
@@ -178,7 +178,7 @@ export namespace Course {
     }
     export const _api = undefined as unknown as Api;
 
-    export function impl<Impl extends Api>(implObj: Impl & ThisType<Impl & typeof Source & { tag: string; Key: any; Orm: typeof Orm }>): Impl & typeof Source & { tag: string; Key: any; Orm: typeof Orm } {
+    export function impl<Impl extends Api>(implObj: Impl & ThisType<typeof Source & { tag: string; Key: any; Orm: typeof Orm }>): typeof Source & { tag: string; Key: any; Orm: typeof Orm } & Impl {
         return _impl(Course, implObj);
     }
 
@@ -243,7 +243,7 @@ export namespace Person {
     }
     export const _api = undefined as unknown as Api;
 
-    export function impl<Impl extends Api>(implObj: Impl & ThisType<Impl & typeof Source & { tag: string; Key: any; Orm: typeof Orm }>): Impl & typeof Source & { tag: string; Key: any; Orm: typeof Orm } {
+    export function impl<Impl extends Api>(implObj: Impl & ThisType<typeof Source & { tag: string; Key: any; Orm: typeof Orm }>): typeof Source & { tag: string; Key: any; Orm: typeof Orm } & Impl {
         return _impl(Person, implObj);
     }
 
@@ -330,7 +330,7 @@ export namespace Student {
     }
     export const _api = undefined as unknown as Api;
 
-    export function impl<Impl extends Api>(implObj: Impl & ThisType<Impl & typeof Source & { tag: string; Key: any; Orm: typeof Orm }>): Impl & typeof Source & { tag: string; Key: any; Orm: typeof Orm } {
+    export function impl<Impl extends Api>(implObj: Impl & ThisType<typeof Source & { tag: string; Key: any; Orm: typeof Orm }>): typeof Source & { tag: string; Key: any; Orm: typeof Orm } & Impl {
         return _impl(Student, implObj);
     }
 
@@ -417,7 +417,7 @@ export namespace Dog {
     }
     export const _api = undefined as unknown as Api;
 
-    export function impl<Impl extends Api>(implObj: Impl & ThisType<Impl & typeof Source & { tag: string; Key: any; Orm: typeof Orm }>): Impl & typeof Source & { tag: string; Key: any; Orm: typeof Orm } {
+    export function impl<Impl extends Api>(implObj: Impl & ThisType<typeof Source & { tag: string; Key: any; Orm: typeof Orm }>): typeof Source & { tag: string; Key: any; Orm: typeof Orm } & Impl {
         return _impl(Dog, implObj);
     }
 
@@ -464,7 +464,7 @@ export namespace Dog {
     }
 }
 
-function _impl<NS extends { Kind: "model"; Meta: { name: string }; Source: any; _api: any; Orm: any; Key?: any }, Impl extends NS["_api"]>(namespace: NS, implObj: Impl & ThisType<Impl & NS["Source"] & { tag: string; Key: NS["Key"]; Orm: NS["Orm"] }>): Impl & NS["Source"] & { tag: string; Key: NS["Key"]; Orm: NS["Orm"] };
+function _impl<NS extends { Kind: "model"; Meta: { name: string }; Source: any; _api: any; Orm: any; Key?: any }, Impl extends NS["_api"]>(namespace: NS, implObj: Impl & ThisType<NS["Source"] & { tag: string; Key: NS["Key"]; Orm: NS["Orm"] }>): NS["Source"] & { tag: string; Key: NS["Key"]; Orm: NS["Orm"] } & Impl;
 function _impl<NS extends { Kind: "service"; Tag: string; _api: any }, Impl extends NS["_api"]>(namespace: NS, implObj: Impl): Impl & { tag: NS["Tag"] };
 function _impl(namespace: any, implObj: any) {
     if (namespace.Kind === "model") {

--- a/tests/e2e/fixtures/kv/backend.ts
+++ b/tests/e2e/fixtures/kv/backend.ts
@@ -34,7 +34,7 @@ export namespace D1BackedModel {
     }
     export const _api = undefined as unknown as Api;
 
-    export function impl<Impl extends Api>(implObj: Impl & ThisType<Impl & typeof Source & { tag: string; Key: typeof Key; Orm: typeof Orm }>): Impl & typeof Source & { tag: string; Key: typeof Key; Orm: typeof Orm } {
+    export function impl<Impl extends Api>(implObj: Impl & ThisType<typeof Source & { tag: string; Key: typeof Key; Orm: typeof Orm }>): typeof Source & { tag: string; Key: typeof Key; Orm: typeof Orm } & Impl {
         return _impl(D1BackedModel, implObj);
     }
 
@@ -101,7 +101,7 @@ export namespace PaginatedKVModel {
     }
     export const _api = undefined as unknown as Api;
 
-    export function impl<Impl extends Api>(implObj: Impl & ThisType<Impl & typeof Source & { tag: string; Key: typeof Key; Orm: typeof Orm }>): Impl & typeof Source & { tag: string; Key: typeof Key; Orm: typeof Orm } {
+    export function impl<Impl extends Api>(implObj: Impl & ThisType<typeof Source & { tag: string; Key: typeof Key; Orm: typeof Orm }>): typeof Source & { tag: string; Key: typeof Key; Orm: typeof Orm } & Impl {
         return _impl(PaginatedKVModel, implObj);
     }
 
@@ -166,7 +166,7 @@ export namespace PureKVModel {
     }
     export const _api = undefined as unknown as Api;
 
-    export function impl<Impl extends Api>(implObj: Impl & ThisType<Impl & typeof Source & { tag: string; Key: typeof Key; Orm: typeof Orm }>): Impl & typeof Source & { tag: string; Key: typeof Key; Orm: typeof Orm } {
+    export function impl<Impl extends Api>(implObj: Impl & ThisType<typeof Source & { tag: string; Key: typeof Key; Orm: typeof Orm }>): typeof Source & { tag: string; Key: typeof Key; Orm: typeof Orm } & Impl {
         return _impl(PureKVModel, implObj);
     }
 
@@ -208,7 +208,7 @@ export namespace PureKVModel {
     }
 }
 
-function _impl<NS extends { Kind: "model"; Meta: { name: string }; Source: any; _api: any; Orm: any; Key?: any }, Impl extends NS["_api"]>(namespace: NS, implObj: Impl & ThisType<Impl & NS["Source"] & { tag: string; Key: NS["Key"]; Orm: NS["Orm"] }>): Impl & NS["Source"] & { tag: string; Key: NS["Key"]; Orm: NS["Orm"] };
+function _impl<NS extends { Kind: "model"; Meta: { name: string }; Source: any; _api: any; Orm: any; Key?: any }, Impl extends NS["_api"]>(namespace: NS, implObj: Impl & ThisType<NS["Source"] & { tag: string; Key: NS["Key"]; Orm: NS["Orm"] }>): NS["Source"] & { tag: string; Key: NS["Key"]; Orm: NS["Orm"] } & Impl;
 function _impl<NS extends { Kind: "service"; Tag: string; _api: any }, Impl extends NS["_api"]>(namespace: NS, implObj: Impl): Impl & { tag: NS["Tag"] };
 function _impl(namespace: any, implObj: any) {
     if (namespace.Kind === "model") {

--- a/tests/e2e/fixtures/middleware/backend.ts
+++ b/tests/e2e/fixtures/middleware/backend.ts
@@ -30,7 +30,7 @@ export namespace Foo {
     }
     export const _api = undefined as unknown as Api;
 
-    export function impl<Impl extends Api>(implObj: Impl & ThisType<Impl & typeof Source & { tag: string; Key: any; Orm: typeof Orm }>): Impl & typeof Source & { tag: string; Key: any; Orm: typeof Orm } {
+    export function impl<Impl extends Api>(implObj: Impl & ThisType<typeof Source & { tag: string; Key: any; Orm: typeof Orm }>): typeof Source & { tag: string; Key: any; Orm: typeof Orm } & Impl {
         return _impl(Foo, implObj);
     }
 
@@ -77,7 +77,7 @@ export namespace Foo {
     }
 }
 
-function _impl<NS extends { Kind: "model"; Meta: { name: string }; Source: any; _api: any; Orm: any; Key?: any }, Impl extends NS["_api"]>(namespace: NS, implObj: Impl & ThisType<Impl & NS["Source"] & { tag: string; Key: NS["Key"]; Orm: NS["Orm"] }>): Impl & NS["Source"] & { tag: string; Key: NS["Key"]; Orm: NS["Orm"] };
+function _impl<NS extends { Kind: "model"; Meta: { name: string }; Source: any; _api: any; Orm: any; Key?: any }, Impl extends NS["_api"]>(namespace: NS, implObj: Impl & ThisType<NS["Source"] & { tag: string; Key: NS["Key"]; Orm: NS["Orm"] }>): NS["Source"] & { tag: string; Key: NS["Key"]; Orm: NS["Orm"] } & Impl;
 function _impl<NS extends { Kind: "service"; Tag: string; _api: any }, Impl extends NS["_api"]>(namespace: NS, implObj: Impl): Impl & { tag: NS["Tag"] };
 function _impl(namespace: any, implObj: any) {
     if (namespace.Kind === "model") {

--- a/tests/e2e/fixtures/multiple_db/backend.ts
+++ b/tests/e2e/fixtures/multiple_db/backend.ts
@@ -27,7 +27,7 @@ export namespace DB1Model {
     }
     export const _api = undefined as unknown as Api;
 
-    export function impl<Impl extends Api>(implObj: Impl & ThisType<Impl & typeof Source & { tag: string; Key: any; Orm: typeof Orm }>): Impl & typeof Source & { tag: string; Key: any; Orm: typeof Orm } {
+    export function impl<Impl extends Api>(implObj: Impl & ThisType<typeof Source & { tag: string; Key: any; Orm: typeof Orm }>): typeof Source & { tag: string; Key: any; Orm: typeof Orm } & Impl {
         return _impl(DB1Model, implObj);
     }
 
@@ -90,7 +90,7 @@ export namespace DB2Model {
     }
     export const _api = undefined as unknown as Api;
 
-    export function impl<Impl extends Api>(implObj: Impl & ThisType<Impl & typeof Source & { tag: string; Key: any; Orm: typeof Orm }>): Impl & typeof Source & { tag: string; Key: any; Orm: typeof Orm } {
+    export function impl<Impl extends Api>(implObj: Impl & ThisType<typeof Source & { tag: string; Key: any; Orm: typeof Orm }>): typeof Source & { tag: string; Key: any; Orm: typeof Orm } & Impl {
         return _impl(DB2Model, implObj);
     }
 
@@ -137,7 +137,7 @@ export namespace DB2Model {
     }
 }
 
-function _impl<NS extends { Kind: "model"; Meta: { name: string }; Source: any; _api: any; Orm: any; Key?: any }, Impl extends NS["_api"]>(namespace: NS, implObj: Impl & ThisType<Impl & NS["Source"] & { tag: string; Key: NS["Key"]; Orm: NS["Orm"] }>): Impl & NS["Source"] & { tag: string; Key: NS["Key"]; Orm: NS["Orm"] };
+function _impl<NS extends { Kind: "model"; Meta: { name: string }; Source: any; _api: any; Orm: any; Key?: any }, Impl extends NS["_api"]>(namespace: NS, implObj: Impl & ThisType<NS["Source"] & { tag: string; Key: NS["Key"]; Orm: NS["Orm"] }>): NS["Source"] & { tag: string; Key: NS["Key"]; Orm: NS["Orm"] } & Impl;
 function _impl<NS extends { Kind: "service"; Tag: string; _api: any }, Impl extends NS["_api"]>(namespace: NS, implObj: Impl): Impl & { tag: NS["Tag"] };
 function _impl(namespace: any, implObj: any) {
     if (namespace.Kind === "model") {

--- a/tests/e2e/fixtures/nullability/backend.ts
+++ b/tests/e2e/fixtures/nullability/backend.ts
@@ -32,7 +32,7 @@ export namespace NullabilityChecks {
     }
     export const _api = undefined as unknown as Api;
 
-    export function impl<Impl extends Api>(implObj: Impl & ThisType<Impl & typeof Source & { tag: string; Key: any; Orm: typeof Orm }>): Impl & typeof Source & { tag: string; Key: any; Orm: typeof Orm } {
+    export function impl<Impl extends Api>(implObj: Impl & ThisType<typeof Source & { tag: string; Key: any; Orm: typeof Orm }>): typeof Source & { tag: string; Key: any; Orm: typeof Orm } & Impl {
         return _impl(NullabilityChecks, implObj);
     }
 
@@ -79,7 +79,7 @@ export namespace NullabilityChecks {
     }
 }
 
-function _impl<NS extends { Kind: "model"; Meta: { name: string }; Source: any; _api: any; Orm: any; Key?: any }, Impl extends NS["_api"]>(namespace: NS, implObj: Impl & ThisType<Impl & NS["Source"] & { tag: string; Key: NS["Key"]; Orm: NS["Orm"] }>): Impl & NS["Source"] & { tag: string; Key: NS["Key"]; Orm: NS["Orm"] };
+function _impl<NS extends { Kind: "model"; Meta: { name: string }; Source: any; _api: any; Orm: any; Key?: any }, Impl extends NS["_api"]>(namespace: NS, implObj: Impl & ThisType<NS["Source"] & { tag: string; Key: NS["Key"]; Orm: NS["Orm"] }>): NS["Source"] & { tag: string; Key: NS["Key"]; Orm: NS["Orm"] } & Impl;
 function _impl<NS extends { Kind: "service"; Tag: string; _api: any }, Impl extends NS["_api"]>(namespace: NS, implObj: Impl): Impl & { tag: NS["Tag"] };
 function _impl(namespace: any, implObj: any) {
     if (namespace.Kind === "model") {

--- a/tests/e2e/fixtures/partials/backend.ts
+++ b/tests/e2e/fixtures/partials/backend.ts
@@ -29,7 +29,7 @@ export namespace Dog {
     }
     export const _api = undefined as unknown as Api;
 
-    export function impl<Impl extends Api>(implObj: Impl & ThisType<Impl & typeof Source & { tag: string; Key: any; Orm: typeof Orm }>): Impl & typeof Source & { tag: string; Key: any; Orm: typeof Orm } {
+    export function impl<Impl extends Api>(implObj: Impl & ThisType<typeof Source & { tag: string; Key: any; Orm: typeof Orm }>): typeof Source & { tag: string; Key: any; Orm: typeof Orm } & Impl {
         return _impl(Dog, implObj);
     }
 
@@ -76,7 +76,7 @@ export namespace Dog {
     }
 }
 
-function _impl<NS extends { Kind: "model"; Meta: { name: string }; Source: any; _api: any; Orm: any; Key?: any }, Impl extends NS["_api"]>(namespace: NS, implObj: Impl & ThisType<Impl & NS["Source"] & { tag: string; Key: NS["Key"]; Orm: NS["Orm"] }>): Impl & NS["Source"] & { tag: string; Key: NS["Key"]; Orm: NS["Orm"] };
+function _impl<NS extends { Kind: "model"; Meta: { name: string }; Source: any; _api: any; Orm: any; Key?: any }, Impl extends NS["_api"]>(namespace: NS, implObj: Impl & ThisType<NS["Source"] & { tag: string; Key: NS["Key"]; Orm: NS["Orm"] }>): NS["Source"] & { tag: string; Key: NS["Key"]; Orm: NS["Orm"] } & Impl;
 function _impl<NS extends { Kind: "service"; Tag: string; _api: any }, Impl extends NS["_api"]>(namespace: NS, implObj: Impl): Impl & { tag: NS["Tag"] };
 function _impl(namespace: any, implObj: any) {
     if (namespace.Kind === "model") {

--- a/tests/e2e/fixtures/poos/backend.ts
+++ b/tests/e2e/fixtures/poos/backend.ts
@@ -38,7 +38,7 @@ export namespace PooAcceptYield {
     }
     export const _api = undefined as unknown as Api;
 
-    export function impl<Impl extends Api>(implObj: Impl & ThisType<Impl & typeof Source & { tag: string; Key: any; Orm: typeof Orm }>): Impl & typeof Source & { tag: string; Key: any; Orm: typeof Orm } {
+    export function impl<Impl extends Api>(implObj: Impl & ThisType<typeof Source & { tag: string; Key: any; Orm: typeof Orm }>): typeof Source & { tag: string; Key: any; Orm: typeof Orm } & Impl {
         return _impl(PooAcceptYield, implObj);
     }
 
@@ -85,7 +85,7 @@ export namespace PooAcceptYield {
     }
 }
 
-function _impl<NS extends { Kind: "model"; Meta: { name: string }; Source: any; _api: any; Orm: any; Key?: any }, Impl extends NS["_api"]>(namespace: NS, implObj: Impl & ThisType<Impl & NS["Source"] & { tag: string; Key: NS["Key"]; Orm: NS["Orm"] }>): Impl & NS["Source"] & { tag: string; Key: NS["Key"]; Orm: NS["Orm"] };
+function _impl<NS extends { Kind: "model"; Meta: { name: string }; Source: any; _api: any; Orm: any; Key?: any }, Impl extends NS["_api"]>(namespace: NS, implObj: Impl & ThisType<NS["Source"] & { tag: string; Key: NS["Key"]; Orm: NS["Orm"] }>): NS["Source"] & { tag: string; Key: NS["Key"]; Orm: NS["Orm"] } & Impl;
 function _impl<NS extends { Kind: "service"; Tag: string; _api: any }, Impl extends NS["_api"]>(namespace: NS, implObj: Impl): Impl & { tag: NS["Tag"] };
 function _impl(namespace: any, implObj: any) {
     if (namespace.Kind === "model") {

--- a/tests/e2e/fixtures/r2/backend.ts
+++ b/tests/e2e/fixtures/r2/backend.ts
@@ -35,7 +35,7 @@ export namespace D1BackedModel {
     }
     export const _api = undefined as unknown as Api;
 
-    export function impl<Impl extends Api>(implObj: Impl & ThisType<Impl & typeof Source & { tag: string; Key: typeof Key; Orm: typeof Orm }>): Impl & typeof Source & { tag: string; Key: typeof Key; Orm: typeof Orm } {
+    export function impl<Impl extends Api>(implObj: Impl & ThisType<typeof Source & { tag: string; Key: typeof Key; Orm: typeof Orm }>): typeof Source & { tag: string; Key: typeof Key; Orm: typeof Orm } & Impl {
         return _impl(D1BackedModel, implObj);
     }
 
@@ -111,7 +111,7 @@ export namespace PureR2Model {
     }
     export const _api = undefined as unknown as Api;
 
-    export function impl<Impl extends Api>(implObj: Impl & ThisType<Impl & typeof Source & { tag: string; Key: typeof Key; Orm: typeof Orm }>): Impl & typeof Source & { tag: string; Key: typeof Key; Orm: typeof Orm } {
+    export function impl<Impl extends Api>(implObj: Impl & ThisType<typeof Source & { tag: string; Key: typeof Key; Orm: typeof Orm }>): typeof Source & { tag: string; Key: typeof Key; Orm: typeof Orm } & Impl {
         return _impl(PureR2Model, implObj);
     }
 
@@ -153,7 +153,7 @@ export namespace PureR2Model {
     }
 }
 
-function _impl<NS extends { Kind: "model"; Meta: { name: string }; Source: any; _api: any; Orm: any; Key?: any }, Impl extends NS["_api"]>(namespace: NS, implObj: Impl & ThisType<Impl & NS["Source"] & { tag: string; Key: NS["Key"]; Orm: NS["Orm"] }>): Impl & NS["Source"] & { tag: string; Key: NS["Key"]; Orm: NS["Orm"] };
+function _impl<NS extends { Kind: "model"; Meta: { name: string }; Source: any; _api: any; Orm: any; Key?: any }, Impl extends NS["_api"]>(namespace: NS, implObj: Impl & ThisType<NS["Source"] & { tag: string; Key: NS["Key"]; Orm: NS["Orm"] }>): NS["Source"] & { tag: string; Key: NS["Key"]; Orm: NS["Orm"] } & Impl;
 function _impl<NS extends { Kind: "service"; Tag: string; _api: any }, Impl extends NS["_api"]>(namespace: NS, implObj: Impl): Impl & { tag: NS["Tag"] };
 function _impl(namespace: any, implObj: any) {
     if (namespace.Kind === "model") {

--- a/tests/e2e/fixtures/services/backend.ts
+++ b/tests/e2e/fixtures/services/backend.ts
@@ -47,7 +47,7 @@ export namespace BarService {
     }
 }
 
-function _impl<NS extends { Kind: "model"; Meta: { name: string }; Source: any; _api: any; Orm: any; Key?: any }, Impl extends NS["_api"]>(namespace: NS, implObj: Impl & ThisType<Impl & NS["Source"] & { tag: string; Key: NS["Key"]; Orm: NS["Orm"] }>): Impl & NS["Source"] & { tag: string; Key: NS["Key"]; Orm: NS["Orm"] };
+function _impl<NS extends { Kind: "model"; Meta: { name: string }; Source: any; _api: any; Orm: any; Key?: any }, Impl extends NS["_api"]>(namespace: NS, implObj: Impl & ThisType<NS["Source"] & { tag: string; Key: NS["Key"]; Orm: NS["Orm"] }>): NS["Source"] & { tag: string; Key: NS["Key"]; Orm: NS["Orm"] } & Impl;
 function _impl<NS extends { Kind: "service"; Tag: string; _api: any }, Impl extends NS["_api"]>(namespace: NS, implObj: Impl): Impl & { tag: NS["Tag"] };
 function _impl(namespace: any, implObj: any) {
     if (namespace.Kind === "model") {


### PR DESCRIPTION
Fixed a bug where the `impl` function would widen the return type to `ApiResult` instead of inferring the specific return type of the method, making it difficult to work with the results without manually type asserting.