### PR TITLE
refactor: Column block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - `crud` tag for Models
 - `instance` tag for Data Source `get` method
 - `inject` tag for API methods to inject environment bindings or injected dependencies into the method.
-- `column` block 
+- `column` block
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - `crud` tag for Models
 - `instance` tag for Data Source `get` method
 - `inject` tag for API methods to inject environment bindings or injected dependencies into the method.
+- `column` block 
 
 ### Changed
 
@@ -20,6 +21,8 @@
 - Services no longer have fields, and are not instantiable. They cannot be injected.
 - `self` on a Service API method throws a semantic error.
 - Removed `env` as a type.
+- Removed `optional` and `paginated` blocks
+- `unique` now references existing fields instead of declaring new ones.
 
 ### Fixed
 

--- a/docs/cidl.js
+++ b/docs/cidl.js
@@ -24,6 +24,7 @@ hljs.registerLanguage("cloesce", function (hljs) {
     "foreign",
     "nav",
     "keyfield",
+    "column",
     "paginated",
     "include",
     "for",

--- a/docs/src/ch1-3-building-and-migrating.md
+++ b/docs/src/ch1-3-building-and-migrating.md
@@ -2,7 +2,7 @@
 
 ## Configuration
 
-Before compilation, a configuration file should be defined in your project root under `cloesce.jsonc`. 
+Before compilation, a configuration file should be defined in your project root under `cloesce.jsonc`.
 
 This file specifies important settings for the Cloesce compiler, such as the paths to your schema files, the URL for your local Workers environment, and the format for generating Wrangler configuration files.
 
@@ -10,7 +10,7 @@ This file specifies important settings for the Cloesce compiler, such as the pat
 {
   "src_paths": ["./src/schema"],
   "workers_url": "http://localhost:5000/api",
-  "wrangler_config_format": "jsonc", // or "toml"
+  "wrangler_config_format": "jsonc" // or "toml"
 }
 ```
 

--- a/docs/src/ch2-0-type-reference.md
+++ b/docs/src/ch2-0-type-reference.md
@@ -53,7 +53,9 @@ model User {
     primary {
         id: int
     }
-    name: string
+    column {
+        name: string
+    }
 }
 
 poo Profile {

--- a/docs/src/ch3-0-environment.md
+++ b/docs/src/ch3-0-environment.md
@@ -79,7 +79,9 @@ model User {
     primary {
         id: int
     }
-    name: string
+    column {
+        name: string
+    }
 }
 ```
 

--- a/docs/src/ch4-1-d1-backed-model.md
+++ b/docs/src/ch4-1-d1-backed-model.md
@@ -43,7 +43,9 @@ model User {
         id: int
     }
 
-    name: string
+    column {
+        name: string
+    }
 }
 ```
 

--- a/docs/src/ch4-2-d1-constraints.md
+++ b/docs/src/ch4-2-d1-constraints.md
@@ -97,6 +97,8 @@ model Person {
 }
 ```
 
+The valid infix qualifiers for a `foreign` block are `primary` and `optional`.
+
 ### Composite Foreign Key
 
 A Model can have a composite primary key by listing multiple fields in a primary block. Similarly, a Model can have a composite foreign key by listing multiple fields in a foreign block.
@@ -162,7 +164,10 @@ model Course {
 
 ## Unique Constraint
 
-The `unique` block allows you to define unique constraints across any number of fields in a Model. It translates to the SQLite `UNIQUE` constraint.
+The `unique (field1, field2, ...)` declaration adds a unique constraint over one or more
+existing fields on a Model. It translates to the SQLite `UNIQUE` constraint.
+
+Unlike `primary` or `optional`, `unique` does **not** declare fields it references fields. A field may participate in any number of unique constraints.
 
 ```cloesce
 model User {
@@ -170,29 +175,25 @@ model User {
         id: int
     }
 
-    unique {
-        email: string
+    email: string
+    username: string
 
-        foreign (Profile::id) {
-            profileId
-        }
-
-        // Infix form is also supported for foreign keys,
-        // even under a unique block
-        foreign (Dog::id) unique {
-            dogId
-        }
+    foreign (Profile::id) {
+        profileId
     }
 
-    unique {
-        username: string
+    foreign (Dog::id) {
+        dogId
     }
+
+    // The combination (email, profileId, dogId) must be unique.
+    unique (email, profileId, dogId)
+
+    // `username` must be unique on its own.
+    unique (username)
+
+    // `dogId` must also be unique on its own — a field can participate in
+    // multiple, independent unique constraints.
+    unique (dogId)
 }
 ```
-
-The above `User` Model has four unique constraints:
-
-1. The combination of `email`, `profileId`, and `dogId` must be unique across all rows in the `User` table.
-2. `dogId` must be unique across all rows in the `User` table.
-3. `username` must be unique across all rows in the `User` table.
-4. `id` is unique across all rows in the `User` table by virtue of being a primary key.

--- a/docs/src/ch4-2-d1-constraints.md
+++ b/docs/src/ch4-2-d1-constraints.md
@@ -73,9 +73,6 @@ Foreign key fields inherit the type of the field they reference. In the above ex
 
 ### Optional Foreign Key
 
-> [!TIP]
-> The `optional` modifier can be used to wrap any number of columns or foreign blocks, modifying all of them to allow `NULL` values.
-
 To allow `NULL` values in a foreign key field, use the `optional` modifier:
 
 ```cloesce
@@ -84,20 +81,13 @@ model Person {
         id: int
     }
 
-    optional {
-        foreign (Dog::id) {
-            dogId
-        }
-    }
-
-    // Or, use the infix notation, which is equivalent:
     foreign (Dog::id) optional {
         dogId
     }
 }
 ```
 
-The valid infix qualifiers for a `foreign` block are `primary` and `optional`.
+`optional` is the only modifier available on a `foreign` block.
 
 ### Composite Foreign Key
 
@@ -138,15 +128,6 @@ model Enrollment {
             courseId
         }
     }
-
-    // Or, equivalently, use the infix notation:
-    foreign (Student::id) primary {
-        studentId
-    }
-
-    foreign (Course::id) primary {
-        courseId
-    }
 }
 
 model Student {
@@ -167,7 +148,7 @@ model Course {
 The `unique (field1, field2, ...)` declaration adds a unique constraint over one or more
 existing fields on a Model. It translates to the SQLite `UNIQUE` constraint.
 
-Unlike `primary` or `optional`, `unique` does **not** declare fields it references fields. A field may participate in any number of unique constraints.
+Unlike `primary` and `column`, `unique` does **not** declare fields; it references existing fields. A field may participate in any number of unique constraints.
 
 ```cloesce
 model User {
@@ -175,8 +156,10 @@ model User {
         id: int
     }
 
-    email: string
-    username: string
+    column {
+        email: string
+        username: string
+    }
 
     foreign (Profile::id) {
         profileId

--- a/docs/src/ch4-2-d1-constraints.md
+++ b/docs/src/ch4-2-d1-constraints.md
@@ -87,8 +87,6 @@ model Person {
 }
 ```
 
-`optional` is the only modifier available on a `foreign` block.
-
 ### Composite Foreign Key
 
 A Model can have a composite primary key by listing multiple fields in a primary block. Similarly, a Model can have a composite foreign key by listing multiple fields in a foreign block.
@@ -146,9 +144,7 @@ model Course {
 ## Unique Constraint
 
 The `unique (field1, field2, ...)` declaration adds a unique constraint over one or more
-existing fields on a Model. It translates to the SQLite `UNIQUE` constraint.
-
-Unlike `primary` and `column`, `unique` does **not** declare fields; it references existing fields. A field may participate in any number of unique constraints.
+existing fields on a Model. It translates to the SQLite `UNIQUE` constraint. A field may participate in any number of unique constraints.
 
 ```cloesce
 model User {

--- a/docs/src/ch4-4-kv-fields.md
+++ b/docs/src/ch4-4-kv-fields.md
@@ -88,7 +88,9 @@ model User {
         id: int
     }
 
-    name: string
+    column {
+        name: string
+    }
 
     kv (my_namespace, "user_settings/{id}") {
         theme: string
@@ -113,20 +115,6 @@ model Settings {
 ```
 
 Here, the `paginated` modifier on the `kv` block indicates that we want to retrieve all key-value pairs in the `my_namespace` namespace that have keys starting with "settings/". The results will be returned in a paginated format, allowing you to handle large datasets efficiently.
-
-Additionally, a block syntax is available:
-
-```cloesce
-model Settings {
-    paginated {
-        kv (my_namespace) {
-            allSettings: json
-        }
-
-        // ...
-    }
-}
-```
 
 ## Generated Types
 

--- a/docs/src/ch4-5-r2-fields.md
+++ b/docs/src/ch4-5-r2-fields.md
@@ -43,7 +43,7 @@ The `{id}` in the key is a placeholder that will be replaced with the actual val
 
 ## Paginated List Queries
 
-Cloesce supports paginated prefix list queries for R2 fields, using the same `paginated` block syntax as KV fields. This allows you to efficiently retrieve lists of objects stored in R2 with a common key prefix, without having to load all objects into memory at once.
+Cloesce supports paginated prefix list queries for R2 fields, using the same `paginated` modifier on the `r2` block as KV fields. This allows you to efficiently retrieve lists of objects stored in R2 with a common key prefix, without having to load all objects into memory at once.
 
 ```cloesce
 model Image {

--- a/docs/src/ch7-0-orm-reference.md
+++ b/docs/src/ch7-0-orm-reference.md
@@ -27,7 +27,9 @@ model User {
         id: int
     }
 
-    name: string
+    column {
+        name: string
+    }
 }
 
 source ByName for User {

--- a/editors/vscode/syntaxes/cloesce.tmLanguage.json
+++ b/editors/vscode/syntaxes/cloesce.tmLanguage.json
@@ -126,7 +126,7 @@
     "structural-keyword": {
       "comment": "Block/sub-block keywords used by the parser",
       "name": "keyword.other.cloesce",
-      "match": "\\b(primary|optional|unique|foreign|nav|keyfield|paginated|include|for|crud|use|internal|instance|lt|lte|gt|gte|step|len|minlen|maxlen|regex)\\b"
+      "match": "\\b(primary|optional|unique|foreign|nav|keyfield|column|paginated|include|for|crud|use|internal|instance|lt|lte|gt|gte|step|len|minlen|maxlen|regex)\\b"
     },
     "binding-keyword": {
       "comment": "Storage binding kinds",

--- a/examples/weather/src/schema/schema.clo
+++ b/examples/weather/src/schema/schema.clo
@@ -18,8 +18,10 @@ model WeatherReport {
         weatherEntries
     }
     
-    title: string
-    description: string
+    column {
+        title: string
+        description: string
+    }
 }
 
 [use db]
@@ -41,10 +43,12 @@ model Weather {
         photo
     }
     
-    dateTime: date
-    location: string
-    temperature: int
-    condition: string
+    column {
+        dateTime: date
+        location: string
+        temperature: int
+        condition: string
+    }
 }
 
 api Weather {

--- a/src/compiler/compiler-test/src/src_str.rs
+++ b/src/compiler/compiler-test/src/src_str.rs
@@ -13,7 +13,7 @@ env {
     }
 }
 
-inject { YouTubeApi } 
+inject { YouTubeApi }
 
 [use db]
 model BasicModel {
@@ -32,16 +32,18 @@ model HasSqlColumnTypes {
         id: int
     }
 
-    str: string
-    integer: int
-    dub: real
-    boo: bool
-    dat: date
-    strNull: option<string>
-    integerNull: option<int>
-    dubNull: option<real>
-    booNull: option<bool>
-    dateNull: option<date>
+    column {
+        str: string
+        integer: int
+        dub: real
+        boo: bool
+        dat: date
+        strNull: option<string>
+        integerNull: option<int>
+        dubNull: option<real>
+        booNull: option<bool>
+        dateNull: option<date>
+    }
 }
 
 [use db]
@@ -96,7 +98,9 @@ model ModelWithCompositePk {
         rowId: int
     }
 
-    name: string
+    column {
+        name: string
+    }
 }
 
 api ModelWithCompositePk {
@@ -154,8 +158,10 @@ model ToyotaPrius {
         id: int
     }
 
-    ownerId: string
-    modelYear: int
+    column {
+        ownerId: string
+        modelYear: int
+    }
 
     keyfield {
         someKey: string
@@ -193,7 +199,9 @@ model ModelWithCruds {
         id: int
     }
 
-    name: string
+    column {
+        name: string
+    }
 
     foreign(BasicModel::id) {
         categoryId
@@ -218,7 +226,9 @@ model ModelWithCustomDs {
         id: int
     }
 
-    name: string
+    column {
+        name: string
+    }
 
     r2 (my_r2, "{id}/data") {
         data

--- a/src/compiler/frontend/src/formatter/mod.rs
+++ b/src/compiler/frontend/src/formatter/mod.rs
@@ -495,7 +495,10 @@ impl<'src> ToDoc<'src> for ModelBlockKind<'src> {
             ModelBlockKind::Kv(kv) => kv.to_doc(ctx),
             ModelBlockKind::R2(r2) => r2.to_doc(ctx),
             ModelBlockKind::Primary(blocks) => model_block(Keyword::Primary.as_str(), blocks, ctx),
-            ModelBlockKind::Unique(blocks) => model_block(Keyword::Unique.as_str(), blocks, ctx),
+            ModelBlockKind::Unique(fields) => Doc::kw(Keyword::Unique)
+                .then(Doc::text(" ("))
+                .then(comma_separated(fields, |sym| ctx.sym_doc(sym, 0, true)))
+                .then(Doc::text(")")),
             ModelBlockKind::Optional(blocks) => {
                 model_block(Keyword::Optional.as_str(), blocks, ctx)
             }
@@ -546,7 +549,6 @@ impl<'src> ToDoc<'src> for ForeignBlock<'src> {
         let qualifier = match &self.qualifier {
             Some(ForeignQualifier::Primary) => Doc::text(" ").then(Doc::kw(Keyword::Primary)),
             Some(ForeignQualifier::Optional) => Doc::text(" ").then(Doc::kw(Keyword::Optional)),
-            Some(ForeignQualifier::Unique) => Doc::text(" ").then(Doc::kw(Keyword::Unique)),
             None => Doc::nil(),
         };
 

--- a/src/compiler/frontend/src/formatter/mod.rs
+++ b/src/compiler/frontend/src/formatter/mod.rs
@@ -22,9 +22,9 @@ use idl::{CidlType, CrudKind, HttpVerb};
 use crate::{
     ApiBlock, ApiBlockMethod, ApiBlockMethodParamKind, ArgumentLiteral, Ast, AstBlockKind,
     DataSourceBlock, DataSourceBlockMethod, EnvBindingBlock, EnvBindingBlockKind, EnvBlock,
-    ForeignBlock, ForeignBlockNav, ForeignQualifier, InjectBlock, Keyword, KvBlock, ModelBlock,
-    ModelBlockKind, NavigationBlock, PaginatedBlockKind, ParsedIncludeTree, PlainOldObjectBlock,
-    R2Block, ServiceBlock, Spd, SqlBlockKind, Symbol, Tag, fmt_cidl_type, lexer::CommentMap,
+    ForeignBlock, ForeignBlockNav, InjectBlock, Keyword, KvBlock, ModelBlock, ModelBlockKind,
+    NavigationBlock, ParsedIncludeTree, PlainOldObjectBlock, R2Block, ServiceBlock, Spd,
+    SqlBlockKind, Symbol, Tag, fmt_cidl_type, lexer::CommentMap,
 };
 use doc::{Doc, render};
 
@@ -488,8 +488,20 @@ impl<'src> ToDoc<'src> for ModelBlockKind<'src> {
             Doc::text(keyword).then(ctx.block(inner, 2))
         }
 
+        fn symbol_block<'src>(
+            keyword: Keyword,
+            syms: &'src [Symbol<'src>],
+            ctx: &FmtCtx<'src>,
+        ) -> Doc<'src> {
+            let mut inner = Doc::nil();
+            for sym in syms {
+                inner = inner.then(ctx.sym_doc(sym, 2, false));
+            }
+            Doc::kw(keyword).then(ctx.block(inner, 2))
+        }
+
         match self {
-            ModelBlockKind::Column(sym) => ctx.sym_doc(sym, 1, true),
+            ModelBlockKind::Column(syms) => symbol_block(Keyword::Column, syms, ctx),
             ModelBlockKind::Foreign(fb) => fb.to_doc(ctx),
             ModelBlockKind::Navigation(nb) => nb.to_doc(ctx),
             ModelBlockKind::Kv(kv) => kv.to_doc(ctx),
@@ -499,19 +511,7 @@ impl<'src> ToDoc<'src> for ModelBlockKind<'src> {
                 .then(Doc::text(" ("))
                 .then(comma_separated(fields, |sym| ctx.sym_doc(sym, 0, true)))
                 .then(Doc::text(")")),
-            ModelBlockKind::Optional(blocks) => {
-                model_block(Keyword::Optional.as_str(), blocks, ctx)
-            }
-            ModelBlockKind::Paginated(blocks) => {
-                model_block(Keyword::Paginated.as_str(), blocks, ctx)
-            }
-            ModelBlockKind::KeyField(syms) => {
-                let mut inner = Doc::nil();
-                for sym in syms {
-                    inner = inner.then(ctx.sym_doc(sym, 2, false));
-                }
-                Doc::kw(Keyword::KeyField).then(ctx.block(inner, 2))
-            }
+            ModelBlockKind::KeyField(syms) => symbol_block(Keyword::KeyField, syms, ctx),
         }
     }
 }
@@ -521,15 +521,6 @@ impl<'src> ToDoc<'src> for SqlBlockKind<'src> {
         match self {
             SqlBlockKind::Column(sym) => ctx.sym_doc(sym, 2, true),
             SqlBlockKind::Foreign(fb) => fb.to_doc(ctx),
-        }
-    }
-}
-
-impl<'src> ToDoc<'src> for PaginatedBlockKind<'src> {
-    fn to_doc(&'src self, ctx: &FmtCtx<'src>) -> Doc<'src> {
-        match self {
-            PaginatedBlockKind::R2(r2) => r2.to_doc(ctx),
-            PaginatedBlockKind::Kv(kv) => kv.to_doc(ctx),
         }
     }
 }
@@ -546,10 +537,10 @@ impl<'src> ToDoc<'src> for ForeignBlock<'src> {
             .then(Doc::text(" ("))
             .then(adjs)
             .then(Doc::text(")"));
-        let qualifier = match &self.qualifier {
-            Some(ForeignQualifier::Primary) => Doc::text(" ").then(Doc::kw(Keyword::Primary)),
-            Some(ForeignQualifier::Optional) => Doc::text(" ").then(Doc::kw(Keyword::Optional)),
-            None => Doc::nil(),
+        let optional = if self.is_optional {
+            Doc::text(" ").then(Doc::kw(Keyword::Optional))
+        } else {
+            Doc::nil()
         };
 
         let mut inner = Doc::nil();
@@ -561,7 +552,7 @@ impl<'src> ToDoc<'src> for ForeignBlock<'src> {
             inner = inner.then(ctx.spd_doc(nav, 2, false));
         }
 
-        doc.then(qualifier).then(ctx.block(inner, 2))
+        doc.then(optional).then(ctx.block(inner, 2))
     }
 }
 

--- a/src/compiler/frontend/src/lib.rs
+++ b/src/compiler/frontend/src/lib.rs
@@ -63,6 +63,7 @@ contextual_keywords! {
     Unique => "unique",
     Paginated => "paginated",
     KeyField => "keyfield",
+    Column => "column",
     For => "for",
     Include => "include",
 
@@ -299,12 +300,6 @@ pub struct NavigationBlock<'src> {
     pub nav: Spd<Symbol<'src>>,
 }
 
-#[derive(Clone)]
-pub enum ForeignQualifier {
-    Primary,
-    Optional,
-}
-
 pub struct ForeignBlockNav<'src> {
     pub symbol: Symbol<'src>,
 }
@@ -325,13 +320,7 @@ pub struct ForeignBlock<'src> {
     /// ```
     pub nav: Option<Spd<ForeignBlockNav<'src>>>,
 
-    pub qualifier: Option<ForeignQualifier>,
-}
-
-impl ForeignBlock<'_> {
-    pub fn is_optional(&self) -> bool {
-        matches!(self.qualifier, Some(ForeignQualifier::Optional))
-    }
+    pub is_optional: bool,
 }
 
 /// `kv(binding, "key/format/{id}") { name: type }`
@@ -368,13 +357,8 @@ pub enum SqlBlockKind<'src> {
     Foreign(ForeignBlock<'src>),
 }
 
-pub enum PaginatedBlockKind<'src> {
-    R2(R2Block<'src>),
-    Kv(KvBlock<'src>),
-}
-
 pub enum ModelBlockKind<'src> {
-    Column(Symbol<'src>),
+    Column(Vec<Symbol<'src>>),
     Foreign(ForeignBlock<'src>),
     Navigation(NavigationBlock<'src>),
     Kv(KvBlock<'src>),
@@ -382,8 +366,6 @@ pub enum ModelBlockKind<'src> {
     Primary(Vec<Spd<SqlBlockKind<'src>>>),
     KeyField(Vec<Symbol<'src>>),
     Unique(Vec<Symbol<'src>>),
-    Paginated(Vec<Spd<PaginatedBlockKind<'src>>>),
-    Optional(Vec<Spd<SqlBlockKind<'src>>>),
 }
 
 impl<'src> ModelBlockKind<'src> {
@@ -393,12 +375,12 @@ impl<'src> ModelBlockKind<'src> {
     /// declaring new ones.
     pub fn symbols(&self) -> Vec<&Symbol<'src>> {
         match self {
-            ModelBlockKind::Column(symbol) => vec![symbol],
+            ModelBlockKind::Column(symbols) => symbols.iter().collect(),
             ModelBlockKind::Foreign(foreign_block) => foreign_block.fields.iter().collect(),
             ModelBlockKind::Navigation(nav_block) => vec![&nav_block.nav.inner],
             ModelBlockKind::Kv(kv_block) => vec![&kv_block.field],
             ModelBlockKind::R2(r2_block) => vec![&r2_block.field],
-            ModelBlockKind::Primary(blocks) | ModelBlockKind::Optional(blocks) => blocks
+            ModelBlockKind::Primary(blocks) => blocks
                 .iter()
                 .flat_map(|spd| match &spd.inner {
                     SqlBlockKind::Column(symbol) => vec![symbol],
@@ -407,13 +389,6 @@ impl<'src> ModelBlockKind<'src> {
                 .collect(),
             ModelBlockKind::KeyField(fields) => fields.iter().collect(),
             ModelBlockKind::Unique(_) => vec![],
-            ModelBlockKind::Paginated(blocks) => blocks
-                .iter()
-                .flat_map(|spd| match &spd.inner {
-                    PaginatedBlockKind::Kv(kv_block) => vec![&kv_block.field],
-                    PaginatedBlockKind::R2(r2_block) => vec![&r2_block.field],
-                })
-                .collect(),
         }
     }
 }
@@ -426,11 +401,11 @@ pub struct ModelBlock<'src> {
 }
 
 impl<'src> ModelBlock<'src> {
-    /// Iterate over all foreign blocks, be they top level or nested in primary/optional blocks
+    /// Iterate over all foreign blocks, be they top level or nested in primary blocks
     pub fn foreign_blocks(&self) -> impl Iterator<Item = &ForeignBlock<'src>> {
         self.blocks.iter().flat_map(|spd| match &spd.inner {
             ModelBlockKind::Foreign(foreign_block) => vec![foreign_block],
-            ModelBlockKind::Primary(blocks) | ModelBlockKind::Optional(blocks) => blocks
+            ModelBlockKind::Primary(blocks) => blocks
                 .iter()
                 .filter_map(|b| match &b.inner {
                     SqlBlockKind::Foreign(fb) => Some(fb),
@@ -449,12 +424,12 @@ impl<'src> ModelBlock<'src> {
         })
     }
 
-    /// Iterate over all SQL column blocks, be they top level or nested in primary/optional blocks
+    /// Iterate over all SQL column blocks, be they top level or nested in primary blocks
     pub fn sql_symbols(&self) -> impl Iterator<Item = &Symbol<'src>> {
         self.blocks.iter().flat_map(|spd| match &spd.inner {
-            ModelBlockKind::Column(symbol) => vec![symbol],
+            ModelBlockKind::Column(symbols) => symbols.iter().collect(),
             ModelBlockKind::Foreign(foreign_block) => foreign_block.fields.iter().collect(),
-            ModelBlockKind::Primary(blocks) | ModelBlockKind::Optional(blocks) => blocks
+            ModelBlockKind::Primary(blocks) => blocks
                 .iter()
                 .filter_map(|b| match &b.inner {
                     SqlBlockKind::Column(symbol) => Some(symbol),

--- a/src/compiler/frontend/src/lib.rs
+++ b/src/compiler/frontend/src/lib.rs
@@ -303,7 +303,6 @@ pub struct NavigationBlock<'src> {
 pub enum ForeignQualifier {
     Primary,
     Optional,
-    Unique,
 }
 
 pub struct ForeignBlockNav<'src> {
@@ -382,12 +381,16 @@ pub enum ModelBlockKind<'src> {
     R2(R2Block<'src>),
     Primary(Vec<Spd<SqlBlockKind<'src>>>),
     KeyField(Vec<Symbol<'src>>),
-    Unique(Vec<Spd<SqlBlockKind<'src>>>),
+    Unique(Vec<Symbol<'src>>),
     Paginated(Vec<Spd<PaginatedBlockKind<'src>>>),
     Optional(Vec<Spd<SqlBlockKind<'src>>>),
 }
 
 impl<'src> ModelBlockKind<'src> {
+    /// Returns the field-declaration symbols introduced by this block.
+    ///
+    /// `Unique` is excluded because it only *references* existing fields rather than
+    /// declaring new ones.
     pub fn symbols(&self) -> Vec<&Symbol<'src>> {
         match self {
             ModelBlockKind::Column(symbol) => vec![symbol],
@@ -395,9 +398,7 @@ impl<'src> ModelBlockKind<'src> {
             ModelBlockKind::Navigation(nav_block) => vec![&nav_block.nav.inner],
             ModelBlockKind::Kv(kv_block) => vec![&kv_block.field],
             ModelBlockKind::R2(r2_block) => vec![&r2_block.field],
-            ModelBlockKind::Primary(blocks)
-            | ModelBlockKind::Unique(blocks)
-            | ModelBlockKind::Optional(blocks) => blocks
+            ModelBlockKind::Primary(blocks) | ModelBlockKind::Optional(blocks) => blocks
                 .iter()
                 .flat_map(|spd| match &spd.inner {
                     SqlBlockKind::Column(symbol) => vec![symbol],
@@ -405,6 +406,7 @@ impl<'src> ModelBlockKind<'src> {
                 })
                 .collect(),
             ModelBlockKind::KeyField(fields) => fields.iter().collect(),
+            ModelBlockKind::Unique(_) => vec![],
             ModelBlockKind::Paginated(blocks) => blocks
                 .iter()
                 .flat_map(|spd| match &spd.inner {
@@ -424,13 +426,11 @@ pub struct ModelBlock<'src> {
 }
 
 impl<'src> ModelBlock<'src> {
-    /// Iterate over all foreign blocks, be they top level or nested in primary/unique/optional blocks
+    /// Iterate over all foreign blocks, be they top level or nested in primary/optional blocks
     pub fn foreign_blocks(&self) -> impl Iterator<Item = &ForeignBlock<'src>> {
         self.blocks.iter().flat_map(|spd| match &spd.inner {
             ModelBlockKind::Foreign(foreign_block) => vec![foreign_block],
-            ModelBlockKind::Primary(blocks)
-            | ModelBlockKind::Unique(blocks)
-            | ModelBlockKind::Optional(blocks) => blocks
+            ModelBlockKind::Primary(blocks) | ModelBlockKind::Optional(blocks) => blocks
                 .iter()
                 .filter_map(|b| match &b.inner {
                     SqlBlockKind::Foreign(fb) => Some(fb),
@@ -449,14 +449,12 @@ impl<'src> ModelBlock<'src> {
         })
     }
 
-    /// Iterate over all SQL column blocks, be they top level or nested in primary/unique/optional blocks
+    /// Iterate over all SQL column blocks, be they top level or nested in primary/optional blocks
     pub fn sql_symbols(&self) -> impl Iterator<Item = &Symbol<'src>> {
         self.blocks.iter().flat_map(|spd| match &spd.inner {
             ModelBlockKind::Column(symbol) => vec![symbol],
             ModelBlockKind::Foreign(foreign_block) => foreign_block.fields.iter().collect(),
-            ModelBlockKind::Primary(blocks)
-            | ModelBlockKind::Unique(blocks)
-            | ModelBlockKind::Optional(blocks) => blocks
+            ModelBlockKind::Primary(blocks) | ModelBlockKind::Optional(blocks) => blocks
                 .iter()
                 .filter_map(|b| match &b.inner {
                     SqlBlockKind::Column(symbol) => Some(symbol),

--- a/src/compiler/frontend/src/parser/model.rs
+++ b/src/compiler/frontend/src/parser/model.rs
@@ -20,7 +20,7 @@ fn foreign_nav_block<'tokens, 'src: 'tokens>()
         .map_spanned(|s| s)
 }
 
-/// `foreign(AdjModel::field1, ...) [primary|optional|unique] { localField ... nav { navName } }`
+/// `foreign(AdjModel::field1, ...) [primary|optional] { localField ... nav { navName } }`
 fn foreign_block<'tokens, 'src: 'tokens>()
 -> impl Parser<'tokens, TokenInput<'tokens, 'src>, ForeignBlock<'src>, Extra<'tokens, 'src>> {
     let adj_ref = symbol()
@@ -30,7 +30,6 @@ fn foreign_block<'tokens, 'src: 'tokens>()
     let qualifier = choice((
         kw!(Primary).to(ForeignQualifier::Primary),
         kw!(Optional).to(ForeignQualifier::Optional),
-        kw!(Unique).to(ForeignQualifier::Unique),
     ))
     .or_not();
 
@@ -128,12 +127,14 @@ pub fn model_block<'tokens, 'src: 'tokens>()
             .map(ModelBlockKind::Optional),
     );
 
-    // `unique { foreign(...) { ... } | typed_symbol ... }`
+    // `unique (field1, field2, ...)`
     let unique_block = kw!(Unique).ignore_then(
-        choice_sql()
-            .repeated()
+        symbol()
+            .separated_by(just(Token::Comma))
+            .at_least(1)
+            .allow_trailing()
             .collect::<Vec<_>>()
-            .delimited_by(just(Token::LBrace), just(Token::RBrace))
+            .delimited_by(just(Token::LParen), just(Token::RParen))
             .map(ModelBlockKind::Unique),
     );
 

--- a/src/compiler/frontend/src/parser/model.rs
+++ b/src/compiler/frontend/src/parser/model.rs
@@ -1,8 +1,8 @@
 use chumsky::prelude::*;
 
 use crate::{
-    AstBlockKind, ForeignBlock, ForeignBlockNav, ForeignQualifier, KvBlock, ModelBlock,
-    ModelBlockKind, NavigationBlock, PaginatedBlockKind, R2Block, Spd, SqlBlockKind, Symbol,
+    AstBlockKind, ForeignBlock, ForeignBlockNav, KvBlock, ModelBlock, ModelBlockKind,
+    NavigationBlock, R2Block, Spd, SqlBlockKind, Symbol,
     lexer::Token,
     parser::{Extra, MapSpanned, TokenInput, kw, symbol, tagged_typed_symbol, tags},
 };
@@ -20,18 +20,12 @@ fn foreign_nav_block<'tokens, 'src: 'tokens>()
         .map_spanned(|s| s)
 }
 
-/// `foreign(AdjModel::field1, ...) [primary|optional] { localField ... nav { navName } }`
+/// `foreign(AdjModel::field1, ...) [optional] { localField ... nav { navName } }`
 fn foreign_block<'tokens, 'src: 'tokens>()
 -> impl Parser<'tokens, TokenInput<'tokens, 'src>, ForeignBlock<'src>, Extra<'tokens, 'src>> {
     let adj_ref = symbol()
         .then_ignore(just(Token::DoubleColon))
         .then(symbol());
-
-    let qualifier = choice((
-        kw!(Primary).to(ForeignQualifier::Primary),
-        kw!(Optional).to(ForeignQualifier::Optional),
-    ))
-    .or_not();
 
     let field = kw!(Nav).not().ignore_then(symbol());
 
@@ -43,7 +37,7 @@ fn foreign_block<'tokens, 'src: 'tokens>()
                 .collect::<Vec<_>>()
                 .delimited_by(just(Token::LParen), just(Token::RParen)),
         )
-        .then(qualifier)
+        .then(kw!(Optional).or_not())
         .then(
             field
                 .repeated()
@@ -51,15 +45,15 @@ fn foreign_block<'tokens, 'src: 'tokens>()
                 .then(foreign_nav_block().or_not())
                 .delimited_by(just(Token::LBrace), just(Token::RBrace)),
         )
-        .map(|((adj, qualifier), (fields, nav))| ForeignBlock {
+        .map(|((adj, optional), (fields, nav))| ForeignBlock {
             adj,
-            qualifier,
+            is_optional: optional.is_some(),
             fields,
             nav,
         })
 }
 
-/// `kv (binding, "key/format/{id}") paginated { ident: cidl_type }`
+/// `kv (binding, "key/format/{id}") [paginated] { ident: cidl_type }`
 fn kv_block<'tokens, 'src: 'tokens>()
 -> impl Parser<'tokens, TokenInput<'tokens, 'src>, KvBlock<'src>, Extra<'tokens, 'src>> {
     kw!(Kv)
@@ -79,7 +73,7 @@ fn kv_block<'tokens, 'src: 'tokens>()
         })
 }
 
-/// `r2(binding, "key/format/{id}") paginated { ident }`
+/// `r2(binding, "key/format/{id}") [paginated] { ident }`
 fn r2_block<'tokens, 'src: 'tokens>()
 -> impl Parser<'tokens, TokenInput<'tokens, 'src>, R2Block<'src>, Extra<'tokens, 'src>> {
     kw!(R2)
@@ -101,30 +95,26 @@ fn r2_block<'tokens, 'src: 'tokens>()
 
 pub fn model_block<'tokens, 'src: 'tokens>()
 -> impl Parser<'tokens, TokenInput<'tokens, 'src>, Spd<AstBlockKind<'src>>, Extra<'tokens, 'src>> {
-    let choice_sql = || {
+    // `column { ([tag]* ident: cidl_type)* }`
+    let column_block = kw!(Column).ignore_then(
+        tagged_typed_symbol()
+            .repeated()
+            .collect::<Vec<_>>()
+            .delimited_by(just(Token::LBrace), just(Token::RBrace))
+            .map(ModelBlockKind::Column),
+    );
+
+    // `primary { typed_symbols... foreign(...) { ... } }`
+    let primary_block = kw!(Primary).ignore_then(
         choice((
             foreign_block().map(SqlBlockKind::Foreign),
             tagged_typed_symbol().map(SqlBlockKind::Column),
         ))
         .map_spanned(|k| k)
-    };
-
-    // `primary { typed_symbols... foreign(...) { ... } }`
-    let primary_block = kw!(Primary).ignore_then(
-        choice_sql()
-            .repeated()
-            .collect::<Vec<_>>()
-            .delimited_by(just(Token::LBrace), just(Token::RBrace))
-            .map(ModelBlockKind::Primary),
-    );
-
-    // `optional { foreign(...) { ... } ... }` — all contained foreigners are nullable
-    let optional_block = kw!(Optional).ignore_then(
-        choice_sql()
-            .repeated()
-            .collect::<Vec<_>>()
-            .delimited_by(just(Token::LBrace), just(Token::RBrace))
-            .map(ModelBlockKind::Optional),
+        .repeated()
+        .collect::<Vec<_>>()
+        .delimited_by(just(Token::LBrace), just(Token::RBrace))
+        .map(ModelBlockKind::Primary),
     );
 
     // `unique (field1, field2, ...)`
@@ -161,45 +151,23 @@ pub fn model_block<'tokens, 'src: 'tokens>()
     };
 
     // `keyfield { ([tag]* ident: cidl_type)* }`
-    let keyfield_block = {
-        kw!(KeyField)
-            .ignore_then(
-                tagged_typed_symbol()
-                    .repeated()
-                    .collect::<Vec<_>>()
-                    .delimited_by(just(Token::LBrace), just(Token::RBrace)),
-            )
-            .map(ModelBlockKind::KeyField)
-    };
-
-    // `paginated { r2(...) { ... } kv(...) { ... } }`
-    let paginated_block = kw!(Paginated).ignore_then(
-        choice((
-            kv_block().map(PaginatedBlockKind::Kv),
-            r2_block().map(PaginatedBlockKind::R2),
-        ))
-        .map_spanned(|k| k)
-        .repeated()
-        .collect::<Vec<_>>()
-        .delimited_by(just(Token::LBrace), just(Token::RBrace))
-        .map(ModelBlockKind::Paginated),
-    );
-
-    let kv = kv_block().map(ModelBlockKind::Kv);
-    let r2 = r2_block().map(ModelBlockKind::R2);
-    let foreign = foreign_block().map(ModelBlockKind::Foreign);
-    let column = tagged_typed_symbol().map(ModelBlockKind::Column);
+    let keyfield_block = kw!(KeyField)
+        .ignore_then(
+            tagged_typed_symbol()
+                .repeated()
+                .collect::<Vec<_>>()
+                .delimited_by(just(Token::LBrace), just(Token::RBrace)),
+        )
+        .map(ModelBlockKind::KeyField);
 
     let sub_blocks = choice((
-        foreign,
-        kv,
-        r2,
-        column,
+        foreign_block().map(ModelBlockKind::Foreign),
+        kv_block().map(ModelBlockKind::Kv),
+        r2_block().map(ModelBlockKind::R2),
+        column_block,
         nav_block,
         keyfield_block,
-        paginated_block,
         primary_block,
-        optional_block,
         unique_block,
     ))
     .boxed();

--- a/src/compiler/frontend/tests/parser_tests.rs
+++ b/src/compiler/frontend/tests/parser_tests.rs
@@ -342,6 +342,9 @@ fn model_primary_unique_optional_foreign() {
         [crud get, save, list]
         model M {
             score: real
+            a: int
+            b: int
+            role: string
 
             primary {
                 id: int
@@ -351,22 +354,17 @@ fn model_primary_unique_optional_foreign() {
 
             foreign(Tag::id) { tagId }
             foreign(Person::id) primary { personId }
-            foreign(Org::id) unique { orgId }
+            foreign(Org::id) { orgId2 }
             foreign(Author::id) optional { authorId }
+            foreign(Dept::id) { deptId }
 
             optional {
                 foreign(Draft::id) { draftId }
             }
 
-            unique {
-                a: int
-                b: int
-            }
-
-            unique {
-                foreign(Dept::id) unique { deptId }
-                role: string
-            }
+            unique (a, b)
+            unique (orgId2)
+            unique (deptId, role)
         }
         "#,
     );
@@ -399,15 +397,15 @@ fn model_primary_unique_optional_foreign() {
             && cruds.iter().any(|c| matches!(c, CrudKind::List))
     );
 
-    let col = m
+    let columns: Vec<&str> = m
         .blocks
         .iter()
-        .find_map(|spd| match &spd.inner {
-            ModelBlockKind::Column(s) => Some(s),
+        .filter_map(|spd| match &spd.inner {
+            ModelBlockKind::Column(s) => Some(s.name),
             _ => None,
         })
-        .unwrap();
-    assert_eq!((col.name, &col.cidl_type), ("score", &CidlType::Real));
+        .collect();
+    assert!(columns.contains(&"score"));
 
     let primary = m
         .blocks
@@ -463,19 +461,6 @@ fn model_primary_unique_optional_foreign() {
         Some(frontend::ForeignQualifier::Primary)
     ));
 
-    let org_fb = m
-        .blocks
-        .iter()
-        .find_map(|spd| match &spd.inner {
-            ModelBlockKind::Foreign(fb) if adj_matches(&fb.adj, &[("Org", "id")]) => Some(fb),
-            _ => None,
-        })
-        .unwrap();
-    assert!(matches!(
-        org_fb.qualifier,
-        Some(frontend::ForeignQualifier::Unique)
-    ));
-
     let author_fb = m
         .blocks
         .iter()
@@ -496,28 +481,19 @@ fn model_primary_unique_optional_foreign() {
         .unwrap();
     assert_eq!(sql_foreigns(opt)[0].fields[0].name, "draftId");
 
-    let uniques: Vec<&Vec<Spd<SqlBlockKind>>> = m
+    let uniques: Vec<Vec<&str>> = m
         .blocks
         .iter()
         .filter_map(|spd| match &spd.inner {
-            ModelBlockKind::Unique(blocks) => Some(blocks),
+            ModelBlockKind::Unique(fields) => {
+                Some(fields.iter().map(|s| s.name).collect::<Vec<_>>())
+            }
             _ => None,
         })
         .collect();
-    assert!(uniques.iter().any(|u| sql_columns(u) == vec!["a", "b"]));
-
-    let dept_unique = uniques
-        .iter()
-        .find(|u| {
-            u.iter()
-                .any(|b| matches!(&b.inner, SqlBlockKind::Foreign(fb) if adj_matches(&fb.adj, &[("Dept", "id")])))
-        })
-        .unwrap();
-    assert_eq!(sql_columns(dept_unique), vec!["role"]);
-    assert!(matches!(
-        sql_foreigns(dept_unique)[0].qualifier,
-        Some(frontend::ForeignQualifier::Unique)
-    ));
+    assert!(uniques.iter().any(|u| u == &vec!["a", "b"]));
+    assert!(uniques.iter().any(|u| u == &vec!["orgId2"]));
+    assert!(uniques.iter().any(|u| u == &vec!["deptId", "role"]));
 }
 
 #[test]

--- a/src/compiler/frontend/tests/parser_tests.rs
+++ b/src/compiler/frontend/tests/parser_tests.rs
@@ -1,7 +1,7 @@
 use compiler_test::lex_and_ast;
 use frontend::{
     ArgumentLiteral, Ast, AstBlockKind, EnvBindingBlockKind, ForeignBlock, Keyword, ModelBlock,
-    ModelBlockKind, PaginatedBlockKind, Spd, SqlBlockKind, Symbol, Tag,
+    ModelBlockKind, Spd, SqlBlockKind, Symbol, Tag,
 };
 use idl::{CidlType, CrudKind, HttpVerb};
 
@@ -341,10 +341,12 @@ fn model_primary_unique_optional_foreign() {
         [use d2_db]
         [crud get, save, list]
         model M {
-            score: real
-            a: int
-            b: int
-            role: string
+            column {
+                score: real
+                a: int
+                b: int
+                role: string
+            }
 
             primary {
                 id: int
@@ -353,14 +355,10 @@ fn model_primary_unique_optional_foreign() {
             }
 
             foreign(Tag::id) { tagId }
-            foreign(Person::id) primary { personId }
             foreign(Org::id) { orgId2 }
             foreign(Author::id) optional { authorId }
             foreign(Dept::id) { deptId }
-
-            optional {
-                foreign(Draft::id) { draftId }
-            }
+            foreign(Draft::id) optional { draftId }
 
             unique (a, b)
             unique (orgId2)
@@ -400,9 +398,9 @@ fn model_primary_unique_optional_foreign() {
     let columns: Vec<&str> = m
         .blocks
         .iter()
-        .filter_map(|spd| match &spd.inner {
-            ModelBlockKind::Column(s) => Some(s.name),
-            _ => None,
+        .flat_map(|spd| match &spd.inner {
+            ModelBlockKind::Column(syms) => syms.iter().map(|s| s.name).collect::<Vec<_>>(),
+            _ => Vec::new(),
         })
         .collect();
     assert!(columns.contains(&"score"));
@@ -446,20 +444,7 @@ fn model_primary_unique_optional_foreign() {
         })
         .unwrap();
     assert_eq!(tag_fb.fields[0].name, "tagId");
-    assert!(tag_fb.qualifier.is_none());
-
-    let person_fb = m
-        .blocks
-        .iter()
-        .find_map(|spd| match &spd.inner {
-            ModelBlockKind::Foreign(fb) if adj_matches(&fb.adj, &[("Person", "id")]) => Some(fb),
-            _ => None,
-        })
-        .unwrap();
-    assert!(matches!(
-        person_fb.qualifier,
-        Some(frontend::ForeignQualifier::Primary)
-    ));
+    assert!(!tag_fb.is_optional);
 
     let author_fb = m
         .blocks
@@ -469,17 +454,18 @@ fn model_primary_unique_optional_foreign() {
             _ => None,
         })
         .unwrap();
-    assert!(author_fb.is_optional());
+    assert!(author_fb.is_optional);
 
-    let opt = m
+    let draft_fb = m
         .blocks
         .iter()
         .find_map(|spd| match &spd.inner {
-            ModelBlockKind::Optional(blocks) => Some(blocks),
+            ModelBlockKind::Foreign(fb) if adj_matches(&fb.adj, &[("Draft", "id")]) => Some(fb),
             _ => None,
         })
         .unwrap();
-    assert_eq!(sql_foreigns(opt)[0].fields[0].name, "draftId");
+    assert!(draft_fb.is_optional);
+    assert_eq!(draft_fb.fields[0].name, "draftId");
 
     let uniques: Vec<Vec<&str>> = m
         .blocks
@@ -569,23 +555,15 @@ fn model_kv_r2_paginated() {
             kv(ns_b, "list/{cursor}") paginated { page: json }
             r2(bucket_a, "photos/{id}.jpg") { photo }
             r2(bucket_b, "thumbs/{cursor}") paginated { thumb }
-            paginated {
-                kv(ns_c, "cache/{id}") { cached_val: string }
-                r2(bucket_c, "archive/{id}") { archive }
-                kv(ns_d, "feed/{cursor}") paginated { feed_item: json }
-                r2(bucket_d, "feed/{cursor}.mp4") paginated { feed_video }
-            }
         }
 
         [crud get, save, list]
         model PureKv {
-            keyfield { 
+            keyfield {
                 key: string
-                secondary: int 
+                secondary: int
             }
-            paginated {
-                kv(kv_ns, "entry/{key}/{secondary}") { entry: json }
-            }
+            kv(kv_ns, "entry/{key}/{secondary}") paginated { entry: json }
         }
         "#,
     );
@@ -644,96 +622,7 @@ fn model_kv_r2_paginated() {
         ("thumbs/{cursor}", "thumb", true)
     );
 
-    let pblocks: Vec<_> = m
-        .blocks
-        .iter()
-        .filter_map(|spd| match &spd.inner {
-            ModelBlockKind::Paginated(blocks) => Some(blocks),
-            _ => None,
-        })
-        .flat_map(|bs| bs.iter())
-        .collect();
-
-    let kv_c = pblocks
-        .iter()
-        .find_map(|b| match &b.inner {
-            PaginatedBlockKind::Kv(kv) if kv.env_binding.name == "ns_c" => Some(kv),
-            _ => None,
-        })
-        .unwrap();
-    assert_eq!(
-        (
-            kv_c.key_format,
-            kv_c.field.name,
-            kv_c.field.cidl_type.clone(),
-            kv_c.is_paginated
-        ),
-        ("cache/{id}", "cached_val", CidlType::String, false)
-    );
-
-    let r2_c = pblocks
-        .iter()
-        .find_map(|b| match &b.inner {
-            PaginatedBlockKind::R2(r2) if r2.env_binding.name == "bucket_c" => Some(r2),
-            _ => None,
-        })
-        .unwrap();
-    assert_eq!(
-        (r2_c.key_format, r2_c.field.name, r2_c.is_paginated),
-        ("archive/{id}", "archive", false)
-    );
-
-    let kv_d = pblocks
-        .iter()
-        .find_map(|b| match &b.inner {
-            PaginatedBlockKind::Kv(kv) if kv.env_binding.name == "ns_d" => Some(kv),
-            _ => None,
-        })
-        .unwrap();
-    assert_eq!(
-        (kv_d.key_format, kv_d.field.name, kv_d.is_paginated),
-        ("feed/{cursor}", "feed_item", true)
-    );
-
-    let r2_d = pblocks
-        .iter()
-        .find_map(|b| match &b.inner {
-            PaginatedBlockKind::R2(r2) if r2.env_binding.name == "bucket_d" => Some(r2),
-            _ => None,
-        })
-        .unwrap();
-    assert_eq!(
-        (r2_d.key_format, r2_d.field.name, r2_d.is_paginated),
-        ("feed/{cursor}.mp4", "feed_video", true)
-    );
-
     let kv_model = find_model(&ast, "PureKv");
-
-    let kv_env_bindings = kv_model
-        .symbol
-        .tags
-        .iter()
-        .filter_map(|t| match &t.inner {
-            Tag::Use { binding } => Some(binding),
-            _ => None,
-        })
-        .collect::<Vec<_>>();
-    assert!(kv_env_bindings.is_empty());
-
-    let kv_cruds: Vec<CrudKind> = kv_model
-        .symbol
-        .tags
-        .iter()
-        .flat_map(|t| match &t.inner {
-            Tag::Crud { kinds } => kinds.iter().map(|k| k.inner.clone()).collect::<Vec<_>>(),
-            _ => Vec::new(),
-        })
-        .collect();
-    assert!(
-        kv_cruds.iter().any(|c| matches!(c, CrudKind::Get))
-            && kv_cruds.iter().any(|c| matches!(c, CrudKind::Save))
-            && kv_cruds.iter().any(|c| matches!(c, CrudKind::List))
-    );
 
     let keyfields: Vec<&str> = kv_model
         .blocks
@@ -749,10 +638,7 @@ fn model_kv_r2_paginated() {
         .blocks
         .iter()
         .find_map(|spd| match &spd.inner {
-            ModelBlockKind::Paginated(blocks) => blocks.iter().find_map(|b| match &b.inner {
-                PaginatedBlockKind::Kv(kv) if kv.env_binding.name == "kv_ns" => Some(kv),
-                _ => None,
-            }),
+            ModelBlockKind::Kv(kv) if kv.env_binding.name == "kv_ns" => Some(kv),
             _ => None,
         })
         .unwrap();
@@ -760,9 +646,10 @@ fn model_kv_r2_paginated() {
         (
             kv_entry.key_format,
             kv_entry.field.name,
-            kv_entry.field.cidl_type.clone()
+            kv_entry.field.cidl_type.clone(),
+            kv_entry.is_paginated,
         ),
-        ("entry/{key}/{secondary}", "entry", CidlType::Json)
+        ("entry/{key}/{secondary}", "entry", CidlType::Json, true)
     );
 }
 
@@ -771,11 +658,13 @@ fn validator_tags() {
     let ast = lex_and_ast(
         r#"
         model M {
-            [regex /[a-z]+/]
-            [minlen 1]
-            [gt 42]
-            [lte 100.5]
-            email: string
+            column {
+                [regex /[a-z]+/]
+                [minlen 1]
+                [gt 42]
+                [lte 100.5]
+                email: string
+            }
         }
         "#,
     );
@@ -785,7 +674,7 @@ fn validator_tags() {
         .blocks
         .iter()
         .find_map(|spd| match &spd.inner {
-            ModelBlockKind::Column(s) => Some(s),
+            ModelBlockKind::Column(syms) => syms.first(),
             _ => None,
         })
         .unwrap();

--- a/src/compiler/frontend/tests/snapshots/formatter_tests__format_non_lossy.snap
+++ b/src/compiler/frontend/tests/snapshots/formatter_tests__format_non_lossy.snap
@@ -1,5 +1,6 @@
 ---
 source: src/compiler/frontend/tests/formatter_tests.rs
+assertion_line: 49
 expression: formatted
 ---
 // Top level comment
@@ -42,16 +43,18 @@ model HasSqlColumnTypes {
         id: int
     }
     
-    str: string
-    integer: int
-    dub: real
-    boo: bool
-    dat: date
-    strNull: option<string>
-    integerNull: option<int>
-    dubNull: option<real>
-    booNull: option<bool>
-    dateNull: option<date>
+    column {
+        str: string
+        integer: int
+        dub: real
+        boo: bool
+        dat: date
+        strNull: option<string>
+        integerNull: option<int>
+        dubNull: option<real>
+        booNull: option<bool>
+        dateNull: option<date>
+    }
 }
 
 [use db]
@@ -108,7 +111,9 @@ model ModelWithCompositePk {
         rowId: int
     }
     
-    name: string
+    column {
+        name: string
+    }
 }
 
 api ModelWithCompositePk {
@@ -166,8 +171,10 @@ model ToyotaPrius {
         id: int
     }
     
-    ownerId: string
-    modelYear: int
+    column {
+        ownerId: string
+        modelYear: int
+    }
     
     keyfield {
         someKey: string
@@ -205,7 +212,9 @@ model ModelWithCruds {
         id: int
     }
     
-    name: string
+    column {
+        name: string
+    }
     
     foreign (BasicModel::id) {
         categoryId
@@ -230,7 +239,9 @@ model ModelWithCustomDs {
         id: int
     }
     
-    name: string
+    column {
+        name: string
+    }
     
     r2 (my_r2, "{id}/data") {
         data

--- a/src/compiler/migrations/tests/migrations_tests.rs
+++ b/src/compiler/migrations/tests/migrations_tests.rs
@@ -114,9 +114,11 @@ async fn migrate_models_scalars(db: SqlitePool) {
                     id: int
                 }
 
-                name: option<string>
-                age: int
-                address: string
+                column {
+                    name: option<string>
+                    age: int
+                    address: string
+                }
             }
         "#,
         );
@@ -417,9 +419,11 @@ async fn migrate_with_rebuild(db: SqlitePool) {
                     id: int
                 }
 
-                name: option<string>
-                age: int
-                address: string
+                column {
+                    name: option<string>
+                    age: int
+                    address: string
+                }
             }
         "#,
         );
@@ -447,9 +451,11 @@ async fn migrate_with_rebuild(db: SqlitePool) {
                     id: int
                 }
 
-                first_name: option<string>
-                age: string
-                favorite_color: string
+                column {
+                    first_name: option<string>
+                    age: string
+                    favorite_color: string
+                }
             }
         "#,
         );
@@ -500,9 +506,11 @@ ALTER TABLE "User" ADD COLUMN "age" text"#
                     id: string
                 }
 
-                first_name: option<string>
-                age: string
-                favorite_color: string
+                column {
+                    first_name: option<string>
+                    age: string
+                    favorite_color: string
+                }
             }
         "#,
         );
@@ -551,9 +559,11 @@ ALTER TABLE "User" ADD COLUMN "age" text"#
                     id: string
                 }
 
-                first_name: option<string>
-                age: string
-                favorite_color: string
+                column {
+                    first_name: option<string>
+                    age: string
+                    favorite_color: string
+                }
 
                 foreign(Dog::id) {
                     dog_id
@@ -595,10 +605,12 @@ ALTER TABLE "User" ADD COLUMN "age" text"#
                         id: int
                     }
 
-                    email: string
-                    first_name: string
-                    last_name: string
-                    age: int
+                    column {
+                        email: string
+                        first_name: string
+                        last_name: string
+                        age: int
+                    }
 
                     unique (email)
                     unique (first_name, last_name)
@@ -637,10 +649,12 @@ ALTER TABLE "User" ADD COLUMN "age" text"#
                         id: int
                     }
 
-                    email: string
-                    first_name: string
-                    last_name: string
-                    age: int
+                    column {
+                        email: string
+                        first_name: string
+                        last_name: string
+                        age: int
+                    }
 
                     unique (email)
                     unique (first_name, last_name)
@@ -681,10 +695,12 @@ ALTER TABLE "User" ADD COLUMN "age" text"#
                         id: int
                     }
 
-                    email: string
-                    first_name: string
-                    last_name: string
-                    age: int
+                    column {
+                        email: string
+                        first_name: string
+                        last_name: string
+                        age: int
+                    }
 
                     unique (email)
                     unique (first_name, last_name)
@@ -725,9 +741,11 @@ async fn migrate_with_rename(db: SqlitePool) {
                     id: int
                 }
 
-                name: option<string>
-                age: int
-                address: string
+                column {
+                    name: option<string>
+                    age: int
+                    address: string
+                }
             }
 
             [use db]
@@ -763,9 +781,11 @@ async fn migrate_with_rename(db: SqlitePool) {
                 id: int
             }
 
-            name: option<string>
-            age: int
-            address: string
+            column {
+                name: option<string>
+                age: int
+                address: string
+            }
         }
 
         [use db]
@@ -974,7 +994,9 @@ async fn migrate_models_composite_pk_and_fk(db: SqlitePool) {
                 userId: int
             }
 
-            name: string
+            column {
+                name: string
+            }
         }
 
         [use db]

--- a/src/compiler/migrations/tests/migrations_tests.rs
+++ b/src/compiler/migrations/tests/migrations_tests.rs
@@ -595,16 +595,13 @@ ALTER TABLE "User" ADD COLUMN "age" text"#
                         id: int
                     }
 
-                    unique {
-                        email: string
-                    }
-
-                    unique {
-                        first_name: string
-                        last_name: string
-                    }
-
+                    email: string
+                    first_name: string
+                    last_name: string
                     age: int
+
+                    unique (email)
+                    unique (first_name, last_name)
                 }
             "#,
             );
@@ -640,18 +637,14 @@ ALTER TABLE "User" ADD COLUMN "age" text"#
                         id: int
                     }
 
-                    unique {
-                        email: string
-                    }
+                    email: string
+                    first_name: string
+                    last_name: string
+                    age: int
 
-                    unique {
-                        first_name: string
-                        last_name: string
-                    }
-
-                    unique {
-                        age: int
-                    }
+                    unique (email)
+                    unique (first_name, last_name)
+                    unique (age)
                 }
             "#,
             );
@@ -688,16 +681,13 @@ ALTER TABLE "User" ADD COLUMN "age" text"#
                         id: int
                     }
 
-                    unique {
-                        email: string
-                    }
-
-                    unique {
-                        first_name: string
-                        last_name: string
-                    }
-
+                    email: string
+                    first_name: string
+                    last_name: string
                     age: int
+
+                    unique (email)
+                    unique (first_name, last_name)
                 }
             "#,
             );

--- a/src/compiler/orm/tests/map_tests.rs
+++ b/src/compiler/orm/tests/map_tests.rs
@@ -55,7 +55,9 @@ fn no_records_returns_empty() {
                 id: int
             }
 
-            name: option<string>
+            column {
+                name: option<string>
+            }
 
             nav(Rider::horseId) {
                 riders
@@ -68,7 +70,9 @@ fn no_records_returns_empty() {
                 id: int
             }
 
-            nickname: option<string>
+            column {
+                nickname: option<string>
+            }
 
             foreign(Horse::id) {
                 horseId
@@ -95,7 +99,9 @@ fn flat() {
                 id: int
             }
 
-            name: option<string>
+            column {
+                name: option<string>
+            }
         }
     "#,
     );
@@ -127,7 +133,9 @@ async fn one_to_one(db: SqlitePool) {
                     id: int
                 }
 
-                name: option<string>
+                column {
+                    name: option<string>
+                }
 
                 foreign(Rider::id) {
                     bestRiderId
@@ -143,7 +151,9 @@ async fn one_to_one(db: SqlitePool) {
                     id: int
                 }
 
-                nickname: option<string>
+                column {
+                    nickname: option<string>
+                }
             }
         "#,
         )
@@ -204,7 +214,9 @@ async fn one_to_many(db: SqlitePool) {
                     id: int
                 }
 
-                name: option<string>
+                column {
+                    name: option<string>
+                }
 
                 nav(Rider::horseId) {
                     riders
@@ -217,7 +229,9 @@ async fn one_to_many(db: SqlitePool) {
                     id: int
                 }
 
-                nickname: option<string>
+                column {
+                    nickname: option<string>
+                }
 
                 foreign(Horse::id) {
                     horseId
@@ -281,7 +295,9 @@ async fn many_to_many(db: SqlitePool) {
                     id: int
                 }
 
-                name: option<string>
+                column {
+                    name: option<string>
+                }
 
                 nav(Course::id) {
                     courses
@@ -294,7 +310,9 @@ async fn many_to_many(db: SqlitePool) {
                     id: int
                 }
 
-                title: option<string>
+                column {
+                    title: option<string>
+                }
 
                 nav(Student::id) {
                     students
@@ -358,7 +376,9 @@ fn composite_primary_key_deduplication() {
                 productId: int
             }
 
-            quantity: int
+            column {
+                quantity: int
+            }
         }
     "#,
     );

--- a/src/compiler/orm/tests/select_tests.rs
+++ b/src/compiler/orm/tests/select_tests.rs
@@ -32,7 +32,9 @@ async fn scalar_model(db: SqlitePool) {
                     id: int
                 }
 
-                name: string
+                column {
+                    name: string
+                }
             }
         "#,
     );
@@ -317,7 +319,9 @@ async fn composite_one_to_one(db: SqlitePool) {
                     student_number: int
                 }
 
-                name: string
+                column {
+                    name: string
+                }
             }
 
             [use db]
@@ -334,7 +338,9 @@ async fn composite_one_to_one(db: SqlitePool) {
                     }
                 }
 
-                course: string
+                column {
+                    course: string
+                }
             }
         "#,
     );
@@ -393,7 +399,9 @@ async fn composite_one_to_many(db: SqlitePool) {
                     order_number: int
                 }
 
-                customer: string
+                column {
+                    customer: string
+                }
 
                 nav(OrderItem::region_id, OrderItem::order_number) {
                     items
@@ -411,7 +419,9 @@ async fn composite_one_to_many(db: SqlitePool) {
                     order_number
                 }
 
-                product: string
+                column {
+                    product: string
+                }
             }
         "#,
     );
@@ -478,7 +488,9 @@ async fn composite_many_to_many(db: SqlitePool) {
                     employee_id: int
                 }
 
-                name: string
+                column {
+                    name: string
+                }
 
                 nav(Course::department_id, Course::course_code) {
                     courses
@@ -492,7 +504,9 @@ async fn composite_many_to_many(db: SqlitePool) {
                     course_code: int
                 }
 
-                title: string
+                column {
+                    title: string
+                }
 
                 nav(Teacher::school_id, Teacher::employee_id) {
                     teachers
@@ -558,8 +572,10 @@ async fn gensym_stops_ambigious_table(db: SqlitePool) {
                     id: int
                 }
 
-                name: string
-                bio: option<string>
+                column {
+                    name: string
+                    bio: option<string>
+                }
 
                 nav(Match::horseId1) {
                     matches
@@ -632,7 +648,9 @@ async fn custom_from(db: SqlitePool) {
                     id: int
                 }
 
-                name: string
+                column {
+                    name: string
+                }
             }
         "#,
     );

--- a/src/compiler/orm/tests/upsert_tests.rs
+++ b/src/compiler/orm/tests/upsert_tests.rs
@@ -25,8 +25,10 @@ async fn upsert_scalar_model(db: SqlitePool) {
                 id: int
             }
 
-            name: string
-            age: int
+            column {
+                name: string
+                age: int
+            }
         }
     "#,
     );
@@ -68,7 +70,9 @@ async fn upsert_auto_increment(db: SqlitePool) {
                 id: int
             }
 
-            name: string
+            column {
+                name: string
+            }
         }
     "#,
     );
@@ -109,7 +113,9 @@ async fn upsert_one_to_one(db: SqlitePool) {
                     id: int
                 }
 
-                name: string
+                column {
+                    name: string
+                }
 
                 foreign(Rider::id) {
                     riderId
@@ -125,7 +131,9 @@ async fn upsert_one_to_one(db: SqlitePool) {
                     id: int
                 }
 
-                nickname: string
+                column {
+                    nickname: string
+                }
             }
         "#,
         )
@@ -178,7 +186,9 @@ async fn upsert_one_to_many(db: SqlitePool) {
                     id: int
                 }
 
-                name: string
+                column {
+                    name: string
+                }
 
                 nav(Rider::horseId) {
                     riders
@@ -191,7 +201,9 @@ async fn upsert_one_to_many(db: SqlitePool) {
                     id: int
                 }
 
-                nickname: string
+                column {
+                    nickname: string
+                }
 
                 foreign(Horse::id) {
                     horseId
@@ -247,7 +259,9 @@ async fn upsert_many_to_many(db: SqlitePool) {
                     id: int
                 }
 
-                name: string
+                column {
+                    name: string
+                }
 
                 nav(Course::id) {
                     courses
@@ -260,7 +274,9 @@ async fn upsert_many_to_many(db: SqlitePool) {
                     id: int
                 }
 
-                title: string
+                column {
+                    title: string
+                }
 
                 nav(Student::id) {
                     students
@@ -314,7 +330,9 @@ async fn upsert_composite_pk(db: SqlitePool) {
                 productId: int
             }
 
-            quantity: int
+            column {
+                quantity: int
+            }
         }
     "#,
     );

--- a/src/compiler/orm/tests/validate_tests.rs
+++ b/src/compiler/orm/tests/validate_tests.rs
@@ -356,7 +356,9 @@ fn objects_partials() {
                     id: int
                 }
 
-                name: string
+                column {
+                    name: string
+                }
             }
         "#,
         );
@@ -382,7 +384,9 @@ fn objects_partials() {
                     id: int
                 }
 
-                name: string
+                column {
+                    name: string
+                }
 
                 nav(Rider::horseId) {
                     riders
@@ -399,7 +403,9 @@ fn objects_partials() {
                     horseId
                 }
 
-                nickname: string
+                column {
+                    nickname: string
+                }
             }
         "#,
         );
@@ -431,7 +437,9 @@ fn objects_partials() {
                     id: int
                 }
 
-                name: string
+                column {
+                    name: string
+                }
             }
         "#,
         );
@@ -1041,12 +1049,14 @@ fn validators_in_model() {
                 id: int
             }
 
-            [gt 0]
-            price: int
+            column {
+                [gt 0]
+                price: int
 
-            [minlen 3]
-            [maxlen 50]
-            name: string
+                [minlen 3]
+                [maxlen 50]
+                name: string
+            }
 
             kv(store, "product/{id}/meta") {
                 [regex /^[a-z0-9_]+$/]

--- a/src/compiler/semantic/src/model.rs
+++ b/src/compiler/semantic/src/model.rs
@@ -211,24 +211,8 @@ impl<'src, 'p> ModelBuilder<'src, 'p> {
                         }
                     }
                 }
-                ModelBlockKind::Unique(blocks) => {
-                    let binding = binding.unwrap().inner;
-                    let qual = FieldQualifiers {
-                        unique_ids: vec![self.unique_seed],
-                        ..Default::default()
-                    };
-                    self.unique_seed += 1;
-
-                    for block in blocks {
-                        match &block.inner {
-                            SqlBlockKind::Column(symbol) => {
-                                self.column(ma, symbol, qual.clone());
-                            }
-                            SqlBlockKind::Foreign(foreign_block) => {
-                                self.foreign(ma, table, binding, foreign_block, qual.clone())
-                            }
-                        }
-                    }
+                ModelBlockKind::Unique(_) => {
+                    // Processed once all columns are built
                 }
                 ModelBlockKind::Optional(blocks) => {
                     let binding = binding.unwrap().inner;
@@ -299,6 +283,12 @@ impl<'src, 'p> ModelBuilder<'src, 'p> {
             }
         }
 
+        for block in self.model.blocks.inners() {
+            if let ModelBlockKind::Unique(fields) = block {
+                self.unique_constraint(ma, fields);
+            }
+        }
+
         if binding.is_some() && !self.has_defined_pk {
             ma.sink
                 .push(SemanticError::D1ModelMissingPrimaryKey { model: self.symbol });
@@ -366,7 +356,7 @@ impl<'src, 'p> ModelBuilder<'src, 'p> {
                 validators,
             },
             foreign_key_reference: None,
-            unique_ids: qual.unique_ids,
+            unique_ids: Vec::new(),
             composite_id: None,
         };
 
@@ -374,6 +364,37 @@ impl<'src, 'p> ModelBuilder<'src, 'p> {
             self.primary_columns.push(col);
         } else {
             self.columns.push(col);
+        }
+    }
+
+    fn unique_constraint(&mut self, ma: &mut ModelAnalysis<'src, 'p>, fields: &'p [Symbol<'src>]) {
+        let mut targets: Vec<usize> = Vec::new();
+        for field in fields {
+            if self
+                .primary_columns
+                .iter()
+                .any(|c| c.field.name == field.name)
+            {
+                // References to primary-key columns can just be
+                // dropped, since the PK is already unique.
+                continue;
+            }
+            match self.columns.iter().position(|c| c.field.name == field.name) {
+                Some(i) => targets.push(i),
+                None => ma
+                    .sink
+                    .push(SemanticError::UnresolvedSymbol { symbol: field }),
+            }
+        }
+
+        if targets.is_empty() {
+            return;
+        }
+
+        let id = self.unique_seed;
+        self.unique_seed += 1;
+        for idx in targets {
+            self.columns[idx].unique_ids.push(id);
         }
     }
 
@@ -388,10 +409,6 @@ impl<'src, 'p> ModelBuilder<'src, 'p> {
         // Add to qualifiers
         qual.is_optional |= fk.is_optional();
         qual.is_primary |= matches!(fk.qualifier, Some(ForeignQualifier::Primary));
-        if matches!(fk.qualifier, Some(ForeignQualifier::Unique)) {
-            qual.unique_ids.push(self.unique_seed);
-            self.unique_seed += 1;
-        }
         self.has_defined_pk |= qual.is_primary;
 
         // Check that the adjacent model exists
@@ -505,7 +522,7 @@ impl<'src, 'p> ModelBuilder<'src, 'p> {
                     model_name: adj_model_sym.name,
                     column_name: adj_field_sym.name,
                 }),
-                unique_ids: qual.unique_ids.clone(),
+                unique_ids: Vec::new(),
                 composite_id,
             };
 
@@ -856,7 +873,6 @@ impl<'src, 'p> ModelBuilder<'src, 'p> {
 struct FieldQualifiers {
     is_optional: bool,
     is_primary: bool,
-    unique_ids: Vec<usize>,
 }
 
 /// Extracts braced variables from a format string.

--- a/src/compiler/semantic/src/model.rs
+++ b/src/compiler/semantic/src/model.rs
@@ -5,8 +5,8 @@ use crate::{
     is_valid_sql_type, kahns, resolve_cidl_type, resolve_validator_tags,
 };
 use frontend::{
-    ForeignBlock, ForeignQualifier, KvBlock, ModelBlock, ModelBlockKind, PaginatedBlockKind,
-    R2Block, Spd, SpdSlice, SqlBlockKind, Symbol, Tag,
+    ForeignBlock, KvBlock, ModelBlock, ModelBlockKind, R2Block, Spd, SpdSlice, SqlBlockKind,
+    Symbol, Tag,
 };
 use idl::{
     CidlType, Column, CrudKind, Field, ForeignKeyReference, KvField, Model, NavigationField,
@@ -147,7 +147,6 @@ impl<'src, 'p> ModelBuilder<'src, 'p> {
                     | ModelBlockKind::Foreign(_)
                     | ModelBlockKind::Primary(_)
                     | ModelBlockKind::Unique(_)
-                    | ModelBlockKind::Optional(_)
                     | ModelBlockKind::Navigation(_)
             )
         });
@@ -186,51 +185,31 @@ impl<'src, 'p> ModelBuilder<'src, 'p> {
 
         for block in self.model.blocks.inners() {
             match block {
-                ModelBlockKind::Column(symbol) => {
-                    self.column(ma, symbol, FieldQualifiers::default());
+                ModelBlockKind::Column(symbols) => {
+                    for symbol in symbols {
+                        self.column(ma, symbol, false);
+                    }
                 }
                 ModelBlockKind::Foreign(fk) => {
                     let binding = binding.unwrap().inner;
-                    self.foreign(ma, table, binding, fk, FieldQualifiers::default());
+                    self.foreign(ma, table, binding, fk, false);
                 }
                 ModelBlockKind::Primary(blocks) => {
                     let binding = binding.unwrap().inner;
-                    let qual = FieldQualifiers {
-                        is_primary: true,
-                        ..Default::default()
-                    };
 
                     for block in blocks {
                         match &block.inner {
                             SqlBlockKind::Column(symbol) => {
-                                self.column(ma, symbol, qual.clone());
+                                self.column(ma, symbol, true);
                             }
                             SqlBlockKind::Foreign(foreign_block) => {
-                                self.foreign(ma, table, binding, foreign_block, qual.clone())
+                                self.foreign(ma, table, binding, foreign_block, true)
                             }
                         }
                     }
                 }
                 ModelBlockKind::Unique(_) => {
                     // Processed once all columns are built
-                }
-                ModelBlockKind::Optional(blocks) => {
-                    let binding = binding.unwrap().inner;
-                    let qual = FieldQualifiers {
-                        is_optional: true,
-                        ..Default::default()
-                    };
-
-                    for block in blocks {
-                        match &block.inner {
-                            SqlBlockKind::Column(symbol) => {
-                                self.column(ma, symbol, qual.clone());
-                            }
-                            SqlBlockKind::Foreign(foreign_block) => {
-                                self.foreign(ma, table, binding, foreign_block, qual.clone())
-                            }
-                        }
-                    }
                 }
                 ModelBlockKind::Navigation(navigation_block) => self.nav(
                     ma,
@@ -268,18 +247,6 @@ impl<'src, 'p> ModelBuilder<'src, 'p> {
                         });
                     }
                 }
-                ModelBlockKind::Paginated(blocks) => {
-                    for block in blocks {
-                        match &block.inner {
-                            PaginatedBlockKind::Kv(kv_block) => {
-                                self.kv_field(ma, table, kv_block);
-                            }
-                            PaginatedBlockKind::R2(r2_block) => {
-                                self.r2_field(ma, table, r2_block);
-                            }
-                        }
-                    }
-                }
             }
         }
 
@@ -312,14 +279,10 @@ impl<'src, 'p> ModelBuilder<'src, 'p> {
         &mut self,
         ma: &mut ModelAnalysis<'src, 'p>,
         symbol: &'p Symbol<'src>,
-        qual: FieldQualifiers,
+        is_primary: bool,
     ) {
-        self.has_defined_pk |= qual.is_primary;
-        let cidl_type = if qual.is_optional {
-            CidlType::nullable(symbol.cidl_type.clone())
-        } else {
-            symbol.cidl_type.clone()
-        };
+        self.has_defined_pk |= is_primary;
+        let cidl_type = symbol.cidl_type.clone();
 
         if !is_valid_sql_type(&cidl_type) {
             ma.sink
@@ -327,7 +290,7 @@ impl<'src, 'p> ModelBuilder<'src, 'p> {
             return;
         }
 
-        if qual.is_primary && cidl_type.is_nullable() {
+        if is_primary && cidl_type.is_nullable() {
             ma.sink
                 .push(SemanticError::NullablePrimaryKey { column: symbol });
             return;
@@ -360,7 +323,7 @@ impl<'src, 'p> ModelBuilder<'src, 'p> {
             composite_id: None,
         };
 
-        if qual.is_primary {
+        if is_primary {
             self.primary_columns.push(col);
         } else {
             self.columns.push(col);
@@ -404,12 +367,9 @@ impl<'src, 'p> ModelBuilder<'src, 'p> {
         table: &SymbolTable<'src, 'p>,
         binding: &'src str,
         fk: &'p ForeignBlock<'src>,
-        mut qual: FieldQualifiers,
+        is_primary: bool,
     ) {
-        // Add to qualifiers
-        qual.is_optional |= fk.is_optional();
-        qual.is_primary |= matches!(fk.qualifier, Some(ForeignQualifier::Primary));
-        self.has_defined_pk |= qual.is_primary;
+        self.has_defined_pk |= is_primary;
 
         // Check that the adjacent model exists
         let adj_model_sym = &fk.adj.first().unwrap().0;
@@ -470,7 +430,7 @@ impl<'src, 'p> ModelBuilder<'src, 'p> {
         };
 
         for (field, (_, adj_field_sym)) in fk.fields.iter().zip(&fk.adj) {
-            if qual.is_primary && fk.is_optional() {
+            if is_primary && fk.is_optional {
                 ma.sink
                     .push(SemanticError::NullablePrimaryKey { column: field });
                 continue;
@@ -493,7 +453,7 @@ impl<'src, 'p> ModelBuilder<'src, 'p> {
                 });
             }
 
-            if !fk.is_optional() {
+            if !fk.is_optional {
                 // One To One: Person has a Dog ..(sql)=> Person has a fk to Dog
                 // Dog must come before Person
                 ma.graph
@@ -511,7 +471,7 @@ impl<'src, 'p> ModelBuilder<'src, 'p> {
                 hash: 0,
                 field: ValidatedField {
                     name: field.name.into(),
-                    cidl_type: if fk.is_optional() {
+                    cidl_type: if fk.is_optional {
                         CidlType::nullable(adj_field_sym.cidl_type.clone())
                     } else {
                         adj_field_sym.cidl_type.clone()
@@ -526,7 +486,7 @@ impl<'src, 'p> ModelBuilder<'src, 'p> {
                 composite_id,
             };
 
-            if qual.is_primary {
+            if is_primary {
                 self.primary_columns.push(col);
             } else {
                 self.columns.push(col);
@@ -867,12 +827,6 @@ impl<'src, 'p> ModelBuilder<'src, 'p> {
 
         Ok(parameters)
     }
-}
-
-#[derive(Default, Clone)]
-struct FieldQualifiers {
-    is_optional: bool,
-    is_primary: bool,
 }
 
 /// Extracts braced variables from a format string.

--- a/src/compiler/semantic/tests/analysis_tests.rs
+++ b/src/compiler/semantic/tests/analysis_tests.rs
@@ -146,7 +146,9 @@ fn d1_model_column_fk_errors() {
                 id: option<int> // primary key cannot be nullable
             }
 
-            id: int // duplicate symbol
+            column {
+                id: int // duplicate symbol
+            }
 
             foreign (Post::invalid) {
                 doesntExist
@@ -641,7 +643,9 @@ fn kv_and_d1_coexist() {
             primary {
                 id: int
             }
-            name: string
+            column {
+                name: string
+            }
 
             kv(my_kv, "users/{id}") {
                 cached: json
@@ -677,7 +681,9 @@ fn api_errors() {
             primary {
                 id: int
             }
-            name: string
+            column {
+                name: string
+            }
         }
 
         // Unknown model reference
@@ -732,7 +738,9 @@ fn api_sets_media_types() {
             primary {
                 id: int
             }
-            name: string
+            column {
+                name: string
+            }
         }
 
         api User {
@@ -775,7 +783,9 @@ fn data_source_errors() {
             primary {
                 id: int
             }
-            name: string
+            column {
+                name: string
+            }
 
             kv(my_kv, "users/{id}") {
                 cached: json
@@ -795,7 +805,9 @@ fn data_source_errors() {
             primary {
                 id: int
             }
-            title: string
+            column {
+                title: string
+            }
 
             foreign(User::id) {
                 authorId
@@ -879,7 +891,9 @@ fn data_source_include_tree_kv_r2() {
             primary {
                 id: int
             }
-            name: string
+            column {
+                name: string
+            }
 
             kv(my_kv, "users/{id}") {
                 cached: json
@@ -1043,8 +1057,10 @@ fn fk_inherits_validators() {
                 id: int 
             }
 
-            [lt 100]
-            age: int
+            column {
+                [lt 100]
+                age: int
+            }
         }
 
         [use my_d1]
@@ -1106,10 +1122,12 @@ fn validator_errors() {
                 name: string
             }
 
-            [step 2.5]                // ValidatorInvalidArgument (float to step)
-            [len 3]                   // ValidatorInvalidForType (length on non-string)
-            [regex "not_a_regex"]     // ValidatorInvalidForType (regex on non-string)
-            age: int
+            column {
+                [step 2.5]                // ValidatorInvalidArgument (float to step)
+                [len 3]                   // ValidatorInvalidForType (length on non-string)
+                [regex "not_a_regex"]     // ValidatorInvalidForType (regex on non-string)
+                age: int
+            }
         }
         "#,
     );
@@ -1136,18 +1154,20 @@ fn validator_valid() {
         model User {
             primary { id: int }
 
-            [gt 0]
-            [gte 0]
-            [lt 200]
-            [lte 150]
-            [step 5]
-            age: int
+            column {
+                [gt 0]
+                [gte 0]
+                [lt 200]
+                [lte 150]
+                [step 5]
+                age: int
 
-            [minlen 1]
-            [maxlen 64]
-            [len 10]
-            [regex /^[a-z]+$/]
-            name: string
+                [minlen 1]
+                [maxlen 64]
+                [len 10]
+                [regex /^[a-z]+$/]
+                name: string
+            }
         }
 
         poo MyPoo {

--- a/src/compiler/semantic/tests/data_source_tests.rs
+++ b/src/compiler/semantic/tests/data_source_tests.rs
@@ -330,7 +330,9 @@ async fn default_data_sources_includes_multiple_one_to_ones(db: SqlitePool) {
             primary {
                 id: int
             }
-            color: string
+            column {
+                color: string
+            }
         }
 
         [use db]
@@ -338,7 +340,9 @@ async fn default_data_sources_includes_multiple_one_to_ones(db: SqlitePool) {
             primary {
                 id: int
             }
-            breed: string
+            column {
+                breed: string
+            }
 
             foreign(Toy::id) {
                 toyId
@@ -351,7 +355,9 @@ async fn default_data_sources_includes_multiple_one_to_ones(db: SqlitePool) {
             primary {
                 id: int
             }
-            name: string
+            column {
+                name: string
+            }
 
             foreign(Dog::id) {
                 dogId
@@ -437,7 +443,9 @@ async fn diamond_does_not_duplicate_traversal(db: SqlitePool) {
             primary {
                 id: int
             }
-            name: string
+            column {
+                name: string
+            }
         }
 
         [use db]
@@ -546,7 +554,9 @@ async fn default_data_sources_composite_pk(db: SqlitePool) {
                 orderId: int
                 productId: int
             }
-            qty: int
+            column {
+                qty: int
+            }
         }
     "#,
     );
@@ -610,7 +620,9 @@ fn resolve_sql_params() {
             primary {
                 id: int
             }
-            price: int
+            column {
+                price: int
+            }
         }
 
         source ById for Item {
@@ -681,7 +693,9 @@ async fn include_placeholder_expands_to_select(db: SqlitePool) {
             primary {
                 id: int
             }
-            title: string
+            column {
+                title: string
+            }
         }
 
         source Recent for Post {

--- a/tests/e2e/fixtures/adv_ds/schema.cloesce
+++ b/tests/e2e/fixtures/adv_ds/schema.cloesce
@@ -11,7 +11,9 @@ model Topping {
         id: int
     }
     
-    name: string
+    column {
+        name: string
+    }
     
     nav (Hamburger::id) {
         hamburger
@@ -25,7 +27,9 @@ model Hamburger {
         id: int
     }
     
-    name: string
+    column {
+        name: string
+    }
     
     nav (Topping::id) {
         toppings

--- a/tests/e2e/fixtures/blobs/schema.cloesce
+++ b/tests/e2e/fixtures/blobs/schema.cloesce
@@ -19,8 +19,10 @@ model BlobHaver {
         id: int
     }
     
-    blob1: blob
-    blob2: blob
+    column {
+        blob1: blob
+        blob2: blob
+    }
 }
 
 api BlobHaver {

--- a/tests/e2e/fixtures/bools_dates_ints/schema.cloesce
+++ b/tests/e2e/fixtures/bools_dates_ints/schema.cloesce
@@ -11,6 +11,8 @@ model Weather {
         id: int
     }
     
-    date: date
-    isRaining: bool
+    column {
+        date: date
+        isRaining: bool
+    }
 }

--- a/tests/e2e/fixtures/composite_keys/schema.cloesce
+++ b/tests/e2e/fixtures/composite_keys/schema.cloesce
@@ -12,7 +12,9 @@ model Student {
         name: string
     }
     
-    favoriteColor: string
+    column {
+        favoriteColor: string
+    }
     
     nav (StudentCourse::studentId, StudentCourse::studentName) {
         studentCourses
@@ -43,7 +45,9 @@ model Course {
         id: int
     }
     
-    title: string
+    column {
+        title: string
+    }
     
     nav (StudentCourse::courseId) {
         studentCourses

--- a/tests/e2e/fixtures/d1_crud/schema.cloesce
+++ b/tests/e2e/fixtures/d1_crud/schema.cloesce
@@ -11,7 +11,9 @@ model CrudHaver {
         id: int
     }
     
-    name: string
+    column {
+        name: string
+    }
 }
 
 api CrudHaver {

--- a/tests/e2e/fixtures/fail/schema.cloesce
+++ b/tests/e2e/fixtures/fail/schema.cloesce
@@ -11,7 +11,9 @@ model FailModel {
         id: int
     }
 
-    name: string
+    column {
+        name: string
+    }
 }
 
 api FailModel {

--- a/tests/e2e/fixtures/kv/schema.cloesce
+++ b/tests/e2e/fixtures/kv/schema.cloesce
@@ -38,8 +38,10 @@ model D1BackedModel {
         kvData: json
     }
 
-    someColumn: real
-    someOtherColumn: string
+    column {
+        someColumn: real
+        someOtherColumn: string
+    }
 }
 
 [crud get]

--- a/tests/e2e/fixtures/multiple_db/schema.cloesce
+++ b/tests/e2e/fixtures/multiple_db/schema.cloesce
@@ -12,7 +12,9 @@ model DB1Model {
         id: int
     }
     
-    someColumn: string
+    column {
+        someColumn: string
+    }
 }
 
 [use db2]
@@ -22,5 +24,7 @@ model DB2Model {
         id: int
     }
     
-    someColumn: string
+    column {
+        someColumn: string
+    }
 }

--- a/tests/e2e/fixtures/nullability/schema.cloesce
+++ b/tests/e2e/fixtures/nullability/schema.cloesce
@@ -10,8 +10,10 @@ model NullabilityChecks {
         id: int
     }
     
-    notNullableString: string
-    nullableString: option<string>
+    column {
+        notNullableString: string
+        nullableString: option<string>
+    }
 }
 
 api NullabilityChecks {

--- a/tests/e2e/fixtures/partials/schema.cloesce
+++ b/tests/e2e/fixtures/partials/schema.cloesce
@@ -11,8 +11,10 @@ model Dog {
         id: int
     }
     
-    name: string
-    age: int
+    column {
+        name: string
+        age: int
+    }
 }
 
 api Dog {

--- a/tests/e2e/fixtures/r2/schema.cloesce
+++ b/tests/e2e/fixtures/r2/schema.cloesce
@@ -46,8 +46,10 @@ model D1BackedModel {
         keyParam: string
     }
     
-    someColumn: real
-    someOtherColumn: string
+    column {
+        someColumn: real
+        someOtherColumn: string
+    }
     
     r2 (bucket1, "d1Backed/{id}/{keyParam}/{someColumn}/{someOtherColumn}") {
         r2Data

--- a/tests/e2e/fixtures/validators/schema.cloesce
+++ b/tests/e2e/fixtures/validators/schema.cloesce
@@ -16,10 +16,12 @@ model Validator {
         id: int
     }
 
-    [regex /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/]
-    [maxlen 255]
-    [minlen 5]
-    email: string
+    column {
+        [regex /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/]
+        [maxlen 255]
+        [minlen 5]
+        email: string
+    }
 
     keyfield {
         [len 10]


### PR DESCRIPTION
- Added a `column` block instead of having bare fields.

- Refactored `unique` to reference existing fields so that it can work in all use cases

- Removed the unnecessary weight of having the `paginated`, `unique` and `optional` blocks.