### PR TITLE
fix: orm envs

### DIFF
--- a/src/compiler/codegen/src/backend/mod.rs
+++ b/src/compiler/codegen/src/backend/mod.rs
@@ -1,5 +1,7 @@
+use std::collections::{BTreeSet, HashSet};
+
 use askama::Template;
-use idl::{CidlType, CloesceIdl};
+use idl::{CidlType, CloesceIdl, IncludeTree, Model};
 
 use crate::mappers::{LanguageTypeMapper, TypeScriptMapper};
 
@@ -11,7 +13,7 @@ struct BackendTemplate<'src> {
     mapper: TypeScriptMapper,
 }
 
-impl BackendTemplate<'_> {
+impl<'src> BackendTemplate<'src> {
     fn map_type(&self, ty: &CidlType<'_>) -> String {
         self.mapper.cidl_type(ty, self.idl)
     }
@@ -22,6 +24,60 @@ impl BackendTemplate<'_> {
 
     fn is_env_injected(&self, name: &str) -> bool {
         !self.idl.injects.contains(&name)
+    }
+
+    /// Wrangler bindings a model's method may touch.
+    ///
+    /// `include` filters which nav/kv/r2 fields are traversed,
+    /// where [None] means "everything"
+    fn model_bindings(
+        &self,
+        model: &Model<'src>,
+        include: Option<&IncludeTree<'src>>,
+    ) -> Vec<&'src str> {
+        let mut visited = HashSet::new();
+        let mut bindings = BTreeSet::new();
+        self.collect_model_bindings(model, include, &mut visited, &mut bindings);
+        bindings.into_iter().collect()
+    }
+
+    fn collect_model_bindings(
+        &self,
+        model: &Model<'src>,
+        include: Option<&IncludeTree<'src>>,
+        visited: &mut HashSet<&'src str>,
+        bindings: &mut BTreeSet<&'src str>,
+    ) {
+        if !visited.insert(model.name) {
+            return;
+        }
+        let included = |name: &str| include.is_none_or(|t| t.0.contains_key(name));
+
+        if let Some(b) = model.d1_binding {
+            bindings.insert(b);
+        }
+        for kv in &model.kv_fields {
+            if included(kv.field.name.as_ref()) {
+                bindings.insert(kv.binding);
+            }
+        }
+        for r2 in &model.r2_fields {
+            if included(r2.field.name.as_ref()) {
+                bindings.insert(r2.binding);
+            }
+        }
+        for nav in &model.navigation_fields {
+            let subtree = match include {
+                Some(t) => match t.0.get(nav.field.name.as_ref()) {
+                    Some(sub) => Some(sub),
+                    None => continue,
+                },
+                None => None,
+            };
+            if let Some(referenced) = self.idl.models.get(nav.model_reference) {
+                self.collect_model_bindings(referenced, subtree, visited, bindings);
+            }
+        }
     }
 }
 

--- a/src/compiler/codegen/templates/backend.ts.jinja
+++ b/src/compiler/codegen/templates/backend.ts.jinja
@@ -2,6 +2,10 @@
 import { HttpResult, KValue, CloesceApp, Orm as CloesceOrm, IncludeTree, DeepPartial, Paginated, CloesceResult } from "cloesce";
 import { R2Bucket, KVNamespace, D1Database, R2Object, D1PreparedStatement, D1Result, R2ObjectBody, ReadableStream } from "@cloudflare/workers-types";
 
+{%- macro env_type(bindings) -%}
+{ {% for (i, b) in bindings.iter().enumerate() %}{{ b }}: Env["{{ b }}"]{% if i + 1 < bindings.len() %}, {% endif %}{% endfor %} }
+{%- endmacro %}
+
 {%- macro api_signature(api, namespace_name) %}
         {{ api.name }}(
 {%- if !api.is_static %}
@@ -65,7 +69,7 @@ export namespace {{ service.name }} {
     export const Tag = "{{ service.name }}" as const;
 
     export interface Api {
-{%- for api in &service.apis %}
+{%- for api in &service.apis -%}
 {{ api_signature(api, service.name) -}}
 {%- endfor %}
     }
@@ -118,10 +122,10 @@ export namespace {{ model.name }} {
     }
 
     export interface Api {
-{%- for api in &model.apis %}
-{%- if !self.is_generated_method(api.name) %}
+{%- for api in &model.apis -%}
+{%- if !self.is_generated_method(api.name) -%}
 {{ api_signature(api, model.name) -}}
-{%- endif %}
+{%- endif -%}
 {%- endfor %}
     }
     export const _api = undefined as unknown as Api;
@@ -135,19 +139,20 @@ export namespace {{ model.name }} {
 {%- for ds in model.data_sources.values() %}
         export const {{ ds.name }} = {
             include: {{ self.mapper.include_tree(&ds.tree) }},
+{%- let ds_bindings = self.model_bindings(model, Some(&ds.tree)) %}
 {%- if let Some(get) = &ds.get %}
-            getQuery: (env: Env{% for param in get.parameters %}, {{ param.parameter.name }}: {{ self.map_type(&param.parameter.cidl_type) }}{% endfor %}) => env.{{ model.d1_binding.unwrap() }}.prepare(`{{ get.raw_sql }}`).bind({% for (i, param) in get.parameters.iter().enumerate() %}{{ param.parameter.name }}{% if i + 1 < get.parameters.len() %}, {% endif %}{% endfor %}),
-            async get(env: Env{% for param in get.parameters %}, {{ param.parameter.name }}: {{ self.map_type(&param.parameter.cidl_type) }}{% endfor %}{% for field in &model.key_fields %}, {{ field.name }}: string{% endfor %}): Promise<CloesceResult<{{ model.name }}.Self | null>> {
+            getQuery: (env: {{ env_type(ds_bindings) }}{% for param in get.parameters %}, {{ param.parameter.name }}: {{ self.map_type(&param.parameter.cidl_type) }}{% endfor %}) => env.{{ model.d1_binding.unwrap() }}.prepare(`{{ get.raw_sql }}`).bind({% for (i, param) in get.parameters.iter().enumerate() %}{{ param.parameter.name }}{% if i + 1 < get.parameters.len() %}, {% endif %}{% endfor %}),
+            async get(env: {{ env_type(ds_bindings) }}{% for param in get.parameters %}, {{ param.parameter.name }}: {{ self.map_type(&param.parameter.cidl_type) }}{% endfor %}{% for field in &model.key_fields %}, {{ field.name }}: string{% endfor %}): Promise<CloesceResult<{{ model.name }}.Self | null>> {
                 return await CloesceOrm.fromEnv(env).get<{{ model.name }}.Self>({{ model.name }}.Meta, {{ model.name }}.Source.{{ ds.name }}.getQuery(env{% for param in get.parameters %}, {{ param.parameter.name }}{% endfor %}), {{ model.name }}.Source.{{ ds.name }}.include, { {% for (i, field) in model.key_fields.iter().enumerate() %}{{ field.name }}{% if i + 1 < model.key_fields.len() %}, {% endif %}{% endfor %} });
             },
 {%- else %}
-            async get(env: Env{% for field in &model.key_fields %}, {{ field.name }}: string{% endfor %}): Promise<{{ model.name }}.Self | null> {
+            async get(env: {{ env_type(ds_bindings) }}{% for field in &model.key_fields %}, {{ field.name }}: string{% endfor %}): Promise<{{ model.name }}.Self | null> {
                 return await CloesceOrm.fromEnv(env).get<{{ model.name }}.Self>({{ model.name }}.Meta, null, {{ model.name }}.Source.{{ ds.name }}.include, { {% for (i, field) in model.key_fields.iter().enumerate() %}{{ field.name }}{% if i + 1 < model.key_fields.len() %}, {% endif %}{% endfor %} });
             },
 {%- endif %}
 {%- if let Some(list) = &ds.list %}
-            listQuery: (env: Env{% for param in list.parameters %}, {{ param.name }}: {{ self.map_type(&param.cidl_type) }}{% endfor %}) => env.{{ model.d1_binding.unwrap() }}.prepare(`{{ list.raw_sql }}`).bind({% for (i, param) in list.parameters.iter().enumerate() %}{{ param.name }}{% if i + 1 < list.parameters.len() %}, {% endif %}{% endfor %}),
-            async list(env: Env{% for param in list.parameters %}, {{ param.name }}: {{ self.map_type(&param.cidl_type) }}{% endfor %}): Promise<CloesceResult<{{ model.name }}.Self[]>> {
+            listQuery: (env: {{ env_type(ds_bindings) }}{% for param in list.parameters %}, {{ param.name }}: {{ self.map_type(&param.cidl_type) }}{% endfor %}) => env.{{ model.d1_binding.unwrap() }}.prepare(`{{ list.raw_sql }}`).bind({% for (i, param) in list.parameters.iter().enumerate() %}{{ param.name }}{% if i + 1 < list.parameters.len() %}, {% endif %}{% endfor %}),
+            async list(env: {{ env_type(ds_bindings) }}{% for param in list.parameters %}, {{ param.name }}: {{ self.map_type(&param.cidl_type) }}{% endfor %}): Promise<CloesceResult<{{ model.name }}.Self[]>> {
                 return await CloesceOrm.fromEnv(env).list<{{ model.name }}.Self>({{ model.name }}.Meta, {{ model.name }}.Source.{{ ds.name }}.listQuery(env{% for param in list.parameters %}, {{ param.name }}{% endfor %}), {{ model.name }}.Source.{{ ds.name }}.include);
             },
 {%- endif %}
@@ -157,16 +162,17 @@ export namespace {{ model.name }} {
 {%- endif %}
 
     export namespace Orm {
-        export async function save(env: Env, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
+{%- let orm_bindings = self.model_bindings(model, None) %}
+        export async function save(env: {{ env_type(orm_bindings) }}, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
             return await CloesceOrm.fromEnv(env).upsert<Self>(Meta, newModel, include);
         }
 
-        export async function get(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self>{% if !model.key_fields.is_empty() %}, keyFields?: { {% for (i, field) in model.key_fields.iter().enumerate() %}{{ field.name }}?: string{% if i + 1 < model.key_fields.len() %}, {% endif %}{% endfor %} }{% endif %} }): Promise<CloesceResult<Self | null>> {
+        export async function get(env: {{ env_type(orm_bindings) }}, args: { query?: D1PreparedStatement, include?: IncludeTree<Self>{% if !model.key_fields.is_empty() %}, keyFields?: { {% for (i, field) in model.key_fields.iter().enumerate() %}{{ field.name }}?: string{% if i + 1 < model.key_fields.len() %}, {% endif %}{% endfor %} }{% endif %} }): Promise<CloesceResult<Self | null>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).get<Self>(Meta, args.query, args.include, {% if !model.key_fields.is_empty() %}args.keyFields ?? {}{% else %}{}{% endif %});
         }
 
-        export async function list(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<{{ model.name }}.Self[]>> {
+        export async function list(env: {{ env_type(orm_bindings) }}, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<{{ model.name }}.Self[]>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).list<Self>(Meta, args.query, args.include);
         }
@@ -179,7 +185,7 @@ export namespace {{ model.name }} {
             return CloesceOrm.map<Self>(Meta, result, Source.Default.include);
         }
 
-        export async function hydrate(env: Env, base: DeepPartial<Self>{% for field in &model.key_fields %}, {{ field.name }}: string{% endfor %}, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
+        export async function hydrate(env: {{ env_type(orm_bindings) }}, base: DeepPartial<Self>{% for field in &model.key_fields %}, {{ field.name }}: string{% endfor %}, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
             return await CloesceOrm.fromEnv(env).hydrate<Self>(Meta, base, { {% for (i, field) in model.key_fields.iter().enumerate() %}{{ field.name }}{% if i + 1 < model.key_fields.len() %}, {% endif %}{% endfor %} }, include);
         }
     }

--- a/src/compiler/codegen/tests/snapshots/backend_tests__backend_code_generation_snapshot.snap
+++ b/src/compiler/codegen/tests/snapshots/backend_tests__backend_code_generation_snapshot.snap
@@ -32,18 +32,14 @@ export namespace BasicService {
     export const Tag = "BasicService" as const;
 
     export interface Api {
-
         downloadData(
         ): ApiResult<CfReadableStream>;
-
         instanceMethod(
             input: number,
         ): ApiResult<number>;
-
         staticMethod(
             input: string,
         ): ApiResult<string>;
-
         uploadData(
             data: CfReadableStream,
         ): ApiResult<boolean>;
@@ -87,28 +83,28 @@ export namespace HasSqlColumnTypes {
     export namespace Source {
         export const Default = {
             include: {},
-            getQuery: (env: Env, id: number) => env.db.prepare(`SELECT "HasSqlColumnTypes"."id" AS "id", "HasSqlColumnTypes"."str" AS "str", "HasSqlColumnTypes"."integer" AS "integer", "HasSqlColumnTypes"."dub" AS "dub", "HasSqlColumnTypes"."boo" AS "boo", "HasSqlColumnTypes"."dat" AS "dat", "HasSqlColumnTypes"."strNull" AS "strNull", "HasSqlColumnTypes"."integerNull" AS "integerNull", "HasSqlColumnTypes"."dubNull" AS "dubNull", "HasSqlColumnTypes"."booNull" AS "booNull", "HasSqlColumnTypes"."dateNull" AS "dateNull" FROM "HasSqlColumnTypes" WHERE "HasSqlColumnTypes"."id" = ?1`).bind(id),
-            async get(env: Env, id: number): Promise<CloesceResult<HasSqlColumnTypes.Self | null>> {
+            getQuery: (env: { db: Env["db"] }, id: number) => env.db.prepare(`SELECT "HasSqlColumnTypes"."id" AS "id", "HasSqlColumnTypes"."str" AS "str", "HasSqlColumnTypes"."integer" AS "integer", "HasSqlColumnTypes"."dub" AS "dub", "HasSqlColumnTypes"."boo" AS "boo", "HasSqlColumnTypes"."dat" AS "dat", "HasSqlColumnTypes"."strNull" AS "strNull", "HasSqlColumnTypes"."integerNull" AS "integerNull", "HasSqlColumnTypes"."dubNull" AS "dubNull", "HasSqlColumnTypes"."booNull" AS "booNull", "HasSqlColumnTypes"."dateNull" AS "dateNull" FROM "HasSqlColumnTypes" WHERE "HasSqlColumnTypes"."id" = ?1`).bind(id),
+            async get(env: { db: Env["db"] }, id: number): Promise<CloesceResult<HasSqlColumnTypes.Self | null>> {
                 return await CloesceOrm.fromEnv(env).get<HasSqlColumnTypes.Self>(HasSqlColumnTypes.Meta, HasSqlColumnTypes.Source.Default.getQuery(env, id), HasSqlColumnTypes.Source.Default.include, {  });
             },
-            listQuery: (env: Env, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "HasSqlColumnTypes"."id" AS "id", "HasSqlColumnTypes"."str" AS "str", "HasSqlColumnTypes"."integer" AS "integer", "HasSqlColumnTypes"."dub" AS "dub", "HasSqlColumnTypes"."boo" AS "boo", "HasSqlColumnTypes"."dat" AS "dat", "HasSqlColumnTypes"."strNull" AS "strNull", "HasSqlColumnTypes"."integerNull" AS "integerNull", "HasSqlColumnTypes"."dubNull" AS "dubNull", "HasSqlColumnTypes"."booNull" AS "booNull", "HasSqlColumnTypes"."dateNull" AS "dateNull" FROM "HasSqlColumnTypes" WHERE "HasSqlColumnTypes"."id" > ?1 ORDER BY "HasSqlColumnTypes"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
-            async list(env: Env, lastSeen_id: number, limit: number): Promise<CloesceResult<HasSqlColumnTypes.Self[]>> {
+            listQuery: (env: { db: Env["db"] }, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "HasSqlColumnTypes"."id" AS "id", "HasSqlColumnTypes"."str" AS "str", "HasSqlColumnTypes"."integer" AS "integer", "HasSqlColumnTypes"."dub" AS "dub", "HasSqlColumnTypes"."boo" AS "boo", "HasSqlColumnTypes"."dat" AS "dat", "HasSqlColumnTypes"."strNull" AS "strNull", "HasSqlColumnTypes"."integerNull" AS "integerNull", "HasSqlColumnTypes"."dubNull" AS "dubNull", "HasSqlColumnTypes"."booNull" AS "booNull", "HasSqlColumnTypes"."dateNull" AS "dateNull" FROM "HasSqlColumnTypes" WHERE "HasSqlColumnTypes"."id" > ?1 ORDER BY "HasSqlColumnTypes"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
+            async list(env: { db: Env["db"] }, lastSeen_id: number, limit: number): Promise<CloesceResult<HasSqlColumnTypes.Self[]>> {
                 return await CloesceOrm.fromEnv(env).list<HasSqlColumnTypes.Self>(HasSqlColumnTypes.Meta, HasSqlColumnTypes.Source.Default.listQuery(env, lastSeen_id, limit), HasSqlColumnTypes.Source.Default.include);
             },
         }
     }
 
     export namespace Orm {
-        export async function save(env: Env, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
+        export async function save(env: { db: Env["db"] }, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
             return await CloesceOrm.fromEnv(env).upsert<Self>(Meta, newModel, include);
         }
 
-        export async function get(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Self | null>> {
+        export async function get(env: { db: Env["db"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Self | null>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).get<Self>(Meta, args.query, args.include, {});
         }
 
-        export async function list(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<HasSqlColumnTypes.Self[]>> {
+        export async function list(env: { db: Env["db"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<HasSqlColumnTypes.Self[]>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).list<Self>(Meta, args.query, args.include);
         }
@@ -121,7 +117,7 @@ export namespace HasSqlColumnTypes {
             return CloesceOrm.map<Self>(Meta, result, Source.Default.include);
         }
 
-        export async function hydrate(env: Env, base: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
+        export async function hydrate(env: { db: Env["db"] }, base: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
             return await CloesceOrm.fromEnv(env).hydrate<Self>(Meta, base, {  }, include);
         }
     }
@@ -150,28 +146,28 @@ export namespace ManyToManyModelA {
     export namespace Source {
         export const Default = {
             include: {"manyToManyNav":{}},
-            getQuery: (env: Env, id: number) => env.db.prepare(`SELECT "ManyToManyModelA"."id" AS "id", "ManyToManyModelAManyToManyModelB_2"."right" AS "manyToManyNav.id" FROM "ManyToManyModelA" LEFT JOIN "ManyToManyModelAManyToManyModelB" AS "ManyToManyModelAManyToManyModelB_2" ON "ManyToManyModelA"."id" = "ManyToManyModelAManyToManyModelB_2"."left" LEFT JOIN "ManyToManyModelB" AS "ManyToManyModelB_1" ON "ManyToManyModelAManyToManyModelB_2"."right" = "ManyToManyModelB_1"."id" WHERE "ManyToManyModelA"."id" = ?1`).bind(id),
-            async get(env: Env, id: number): Promise<CloesceResult<ManyToManyModelA.Self | null>> {
+            getQuery: (env: { db: Env["db"] }, id: number) => env.db.prepare(`SELECT "ManyToManyModelA"."id" AS "id", "ManyToManyModelAManyToManyModelB_2"."right" AS "manyToManyNav.id" FROM "ManyToManyModelA" LEFT JOIN "ManyToManyModelAManyToManyModelB" AS "ManyToManyModelAManyToManyModelB_2" ON "ManyToManyModelA"."id" = "ManyToManyModelAManyToManyModelB_2"."left" LEFT JOIN "ManyToManyModelB" AS "ManyToManyModelB_1" ON "ManyToManyModelAManyToManyModelB_2"."right" = "ManyToManyModelB_1"."id" WHERE "ManyToManyModelA"."id" = ?1`).bind(id),
+            async get(env: { db: Env["db"] }, id: number): Promise<CloesceResult<ManyToManyModelA.Self | null>> {
                 return await CloesceOrm.fromEnv(env).get<ManyToManyModelA.Self>(ManyToManyModelA.Meta, ManyToManyModelA.Source.Default.getQuery(env, id), ManyToManyModelA.Source.Default.include, {  });
             },
-            listQuery: (env: Env, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "ManyToManyModelA"."id" AS "id", "ManyToManyModelAManyToManyModelB_2"."right" AS "manyToManyNav.id" FROM "ManyToManyModelA" LEFT JOIN "ManyToManyModelAManyToManyModelB" AS "ManyToManyModelAManyToManyModelB_2" ON "ManyToManyModelA"."id" = "ManyToManyModelAManyToManyModelB_2"."left" LEFT JOIN "ManyToManyModelB" AS "ManyToManyModelB_1" ON "ManyToManyModelAManyToManyModelB_2"."right" = "ManyToManyModelB_1"."id" WHERE "ManyToManyModelA"."id" > ?1 ORDER BY "ManyToManyModelA"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
-            async list(env: Env, lastSeen_id: number, limit: number): Promise<CloesceResult<ManyToManyModelA.Self[]>> {
+            listQuery: (env: { db: Env["db"] }, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "ManyToManyModelA"."id" AS "id", "ManyToManyModelAManyToManyModelB_2"."right" AS "manyToManyNav.id" FROM "ManyToManyModelA" LEFT JOIN "ManyToManyModelAManyToManyModelB" AS "ManyToManyModelAManyToManyModelB_2" ON "ManyToManyModelA"."id" = "ManyToManyModelAManyToManyModelB_2"."left" LEFT JOIN "ManyToManyModelB" AS "ManyToManyModelB_1" ON "ManyToManyModelAManyToManyModelB_2"."right" = "ManyToManyModelB_1"."id" WHERE "ManyToManyModelA"."id" > ?1 ORDER BY "ManyToManyModelA"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
+            async list(env: { db: Env["db"] }, lastSeen_id: number, limit: number): Promise<CloesceResult<ManyToManyModelA.Self[]>> {
                 return await CloesceOrm.fromEnv(env).list<ManyToManyModelA.Self>(ManyToManyModelA.Meta, ManyToManyModelA.Source.Default.listQuery(env, lastSeen_id, limit), ManyToManyModelA.Source.Default.include);
             },
         }
     }
 
     export namespace Orm {
-        export async function save(env: Env, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
+        export async function save(env: { db: Env["db"] }, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
             return await CloesceOrm.fromEnv(env).upsert<Self>(Meta, newModel, include);
         }
 
-        export async function get(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Self | null>> {
+        export async function get(env: { db: Env["db"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Self | null>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).get<Self>(Meta, args.query, args.include, {});
         }
 
-        export async function list(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<ManyToManyModelA.Self[]>> {
+        export async function list(env: { db: Env["db"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<ManyToManyModelA.Self[]>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).list<Self>(Meta, args.query, args.include);
         }
@@ -184,7 +180,7 @@ export namespace ManyToManyModelA {
             return CloesceOrm.map<Self>(Meta, result, Source.Default.include);
         }
 
-        export async function hydrate(env: Env, base: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
+        export async function hydrate(env: { db: Env["db"] }, base: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
             return await CloesceOrm.fromEnv(env).hydrate<Self>(Meta, base, {  }, include);
         }
     }
@@ -213,28 +209,28 @@ export namespace ManyToManyModelB {
     export namespace Source {
         export const Default = {
             include: {"manyToManyNav":{}},
-            getQuery: (env: Env, id: number) => env.db.prepare(`SELECT "ManyToManyModelB"."id" AS "id", "ManyToManyModelAManyToManyModelB_2"."left" AS "manyToManyNav.id" FROM "ManyToManyModelB" LEFT JOIN "ManyToManyModelAManyToManyModelB" AS "ManyToManyModelAManyToManyModelB_2" ON "ManyToManyModelB"."id" = "ManyToManyModelAManyToManyModelB_2"."right" LEFT JOIN "ManyToManyModelA" AS "ManyToManyModelA_1" ON "ManyToManyModelAManyToManyModelB_2"."left" = "ManyToManyModelA_1"."id" WHERE "ManyToManyModelB"."id" = ?1`).bind(id),
-            async get(env: Env, id: number): Promise<CloesceResult<ManyToManyModelB.Self | null>> {
+            getQuery: (env: { db: Env["db"] }, id: number) => env.db.prepare(`SELECT "ManyToManyModelB"."id" AS "id", "ManyToManyModelAManyToManyModelB_2"."left" AS "manyToManyNav.id" FROM "ManyToManyModelB" LEFT JOIN "ManyToManyModelAManyToManyModelB" AS "ManyToManyModelAManyToManyModelB_2" ON "ManyToManyModelB"."id" = "ManyToManyModelAManyToManyModelB_2"."right" LEFT JOIN "ManyToManyModelA" AS "ManyToManyModelA_1" ON "ManyToManyModelAManyToManyModelB_2"."left" = "ManyToManyModelA_1"."id" WHERE "ManyToManyModelB"."id" = ?1`).bind(id),
+            async get(env: { db: Env["db"] }, id: number): Promise<CloesceResult<ManyToManyModelB.Self | null>> {
                 return await CloesceOrm.fromEnv(env).get<ManyToManyModelB.Self>(ManyToManyModelB.Meta, ManyToManyModelB.Source.Default.getQuery(env, id), ManyToManyModelB.Source.Default.include, {  });
             },
-            listQuery: (env: Env, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "ManyToManyModelB"."id" AS "id", "ManyToManyModelAManyToManyModelB_2"."left" AS "manyToManyNav.id" FROM "ManyToManyModelB" LEFT JOIN "ManyToManyModelAManyToManyModelB" AS "ManyToManyModelAManyToManyModelB_2" ON "ManyToManyModelB"."id" = "ManyToManyModelAManyToManyModelB_2"."right" LEFT JOIN "ManyToManyModelA" AS "ManyToManyModelA_1" ON "ManyToManyModelAManyToManyModelB_2"."left" = "ManyToManyModelA_1"."id" WHERE "ManyToManyModelB"."id" > ?1 ORDER BY "ManyToManyModelB"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
-            async list(env: Env, lastSeen_id: number, limit: number): Promise<CloesceResult<ManyToManyModelB.Self[]>> {
+            listQuery: (env: { db: Env["db"] }, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "ManyToManyModelB"."id" AS "id", "ManyToManyModelAManyToManyModelB_2"."left" AS "manyToManyNav.id" FROM "ManyToManyModelB" LEFT JOIN "ManyToManyModelAManyToManyModelB" AS "ManyToManyModelAManyToManyModelB_2" ON "ManyToManyModelB"."id" = "ManyToManyModelAManyToManyModelB_2"."right" LEFT JOIN "ManyToManyModelA" AS "ManyToManyModelA_1" ON "ManyToManyModelAManyToManyModelB_2"."left" = "ManyToManyModelA_1"."id" WHERE "ManyToManyModelB"."id" > ?1 ORDER BY "ManyToManyModelB"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
+            async list(env: { db: Env["db"] }, lastSeen_id: number, limit: number): Promise<CloesceResult<ManyToManyModelB.Self[]>> {
                 return await CloesceOrm.fromEnv(env).list<ManyToManyModelB.Self>(ManyToManyModelB.Meta, ManyToManyModelB.Source.Default.listQuery(env, lastSeen_id, limit), ManyToManyModelB.Source.Default.include);
             },
         }
     }
 
     export namespace Orm {
-        export async function save(env: Env, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
+        export async function save(env: { db: Env["db"] }, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
             return await CloesceOrm.fromEnv(env).upsert<Self>(Meta, newModel, include);
         }
 
-        export async function get(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Self | null>> {
+        export async function get(env: { db: Env["db"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Self | null>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).get<Self>(Meta, args.query, args.include, {});
         }
 
-        export async function list(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<ManyToManyModelB.Self[]>> {
+        export async function list(env: { db: Env["db"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<ManyToManyModelB.Self[]>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).list<Self>(Meta, args.query, args.include);
         }
@@ -247,7 +243,7 @@ export namespace ManyToManyModelB {
             return CloesceOrm.map<Self>(Meta, result, Source.Default.include);
         }
 
-        export async function hydrate(env: Env, base: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
+        export async function hydrate(env: { db: Env["db"] }, base: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
             return await CloesceOrm.fromEnv(env).hydrate<Self>(Meta, base, {  }, include);
         }
     }
@@ -267,7 +263,6 @@ export namespace ModelWithCompositePk {
     }
 
     export interface Api {
-
         instanceMethod(
             self: ModelWithCompositePk.Self,
             env: {
@@ -285,28 +280,28 @@ export namespace ModelWithCompositePk {
     export namespace Source {
         export const Default = {
             include: {},
-            getQuery: (env: Env, tenantId: string, rowId: number) => env.db.prepare(`SELECT "ModelWithCompositePk"."tenantId" AS "tenantId", "ModelWithCompositePk"."rowId" AS "rowId", "ModelWithCompositePk"."name" AS "name" FROM "ModelWithCompositePk" WHERE ("ModelWithCompositePk"."tenantId", "ModelWithCompositePk"."rowId") = (?1, ?2)`).bind(tenantId, rowId),
-            async get(env: Env, tenantId: string, rowId: number): Promise<CloesceResult<ModelWithCompositePk.Self | null>> {
+            getQuery: (env: { db: Env["db"] }, tenantId: string, rowId: number) => env.db.prepare(`SELECT "ModelWithCompositePk"."tenantId" AS "tenantId", "ModelWithCompositePk"."rowId" AS "rowId", "ModelWithCompositePk"."name" AS "name" FROM "ModelWithCompositePk" WHERE ("ModelWithCompositePk"."tenantId", "ModelWithCompositePk"."rowId") = (?1, ?2)`).bind(tenantId, rowId),
+            async get(env: { db: Env["db"] }, tenantId: string, rowId: number): Promise<CloesceResult<ModelWithCompositePk.Self | null>> {
                 return await CloesceOrm.fromEnv(env).get<ModelWithCompositePk.Self>(ModelWithCompositePk.Meta, ModelWithCompositePk.Source.Default.getQuery(env, tenantId, rowId), ModelWithCompositePk.Source.Default.include, {  });
             },
-            listQuery: (env: Env, lastSeen_tenantId: string, lastSeen_rowId: number, limit: number) => env.db.prepare(`SELECT "ModelWithCompositePk"."tenantId" AS "tenantId", "ModelWithCompositePk"."rowId" AS "rowId", "ModelWithCompositePk"."name" AS "name" FROM "ModelWithCompositePk" WHERE ("ModelWithCompositePk"."tenantId", "ModelWithCompositePk"."rowId") > (?1, ?2) ORDER BY "ModelWithCompositePk"."tenantId" ASC, "ModelWithCompositePk"."rowId" ASC LIMIT ?3`).bind(lastSeen_tenantId, lastSeen_rowId, limit),
-            async list(env: Env, lastSeen_tenantId: string, lastSeen_rowId: number, limit: number): Promise<CloesceResult<ModelWithCompositePk.Self[]>> {
+            listQuery: (env: { db: Env["db"] }, lastSeen_tenantId: string, lastSeen_rowId: number, limit: number) => env.db.prepare(`SELECT "ModelWithCompositePk"."tenantId" AS "tenantId", "ModelWithCompositePk"."rowId" AS "rowId", "ModelWithCompositePk"."name" AS "name" FROM "ModelWithCompositePk" WHERE ("ModelWithCompositePk"."tenantId", "ModelWithCompositePk"."rowId") > (?1, ?2) ORDER BY "ModelWithCompositePk"."tenantId" ASC, "ModelWithCompositePk"."rowId" ASC LIMIT ?3`).bind(lastSeen_tenantId, lastSeen_rowId, limit),
+            async list(env: { db: Env["db"] }, lastSeen_tenantId: string, lastSeen_rowId: number, limit: number): Promise<CloesceResult<ModelWithCompositePk.Self[]>> {
                 return await CloesceOrm.fromEnv(env).list<ModelWithCompositePk.Self>(ModelWithCompositePk.Meta, ModelWithCompositePk.Source.Default.listQuery(env, lastSeen_tenantId, lastSeen_rowId, limit), ModelWithCompositePk.Source.Default.include);
             },
         }
     }
 
     export namespace Orm {
-        export async function save(env: Env, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
+        export async function save(env: { db: Env["db"] }, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
             return await CloesceOrm.fromEnv(env).upsert<Self>(Meta, newModel, include);
         }
 
-        export async function get(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Self | null>> {
+        export async function get(env: { db: Env["db"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Self | null>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).get<Self>(Meta, args.query, args.include, {});
         }
 
-        export async function list(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<ModelWithCompositePk.Self[]>> {
+        export async function list(env: { db: Env["db"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<ModelWithCompositePk.Self[]>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).list<Self>(Meta, args.query, args.include);
         }
@@ -319,7 +314,7 @@ export namespace ModelWithCompositePk {
             return CloesceOrm.map<Self>(Meta, result, Source.Default.include);
         }
 
-        export async function hydrate(env: Env, base: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
+        export async function hydrate(env: { db: Env["db"] }, base: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
             return await CloesceOrm.fromEnv(env).hydrate<Self>(Meta, base, {  }, include);
         }
     }
@@ -350,7 +345,6 @@ export namespace ModelWithKv {
     }
 
     export interface Api {
-
         instanceMethod(
             self: ModelWithKv.Self,
             env: {
@@ -358,11 +352,9 @@ export namespace ModelWithKv {
             },
             input: string,
         ): ApiResult<string>;
-
         staticMethod(
             input: number,
         ): ApiResult<number>;
-
         hasKvParamAndRes(
             self: ModelWithKv.Self,
             input: KValue<string>,
@@ -377,23 +369,23 @@ export namespace ModelWithKv {
     export namespace Source {
         export const Default = {
             include: {"manyValues":{},"someValue":{},"streamValue":{}},
-            async get(env: Env, id1: string, id2: string): Promise<ModelWithKv.Self | null> {
+            async get(env: { my_kv: Env["my_kv"] }, id1: string, id2: string): Promise<ModelWithKv.Self | null> {
                 return await CloesceOrm.fromEnv(env).get<ModelWithKv.Self>(ModelWithKv.Meta, null, ModelWithKv.Source.Default.include, { id1, id2 });
             },
         }
     }
 
     export namespace Orm {
-        export async function save(env: Env, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
+        export async function save(env: { my_kv: Env["my_kv"] }, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
             return await CloesceOrm.fromEnv(env).upsert<Self>(Meta, newModel, include);
         }
 
-        export async function get(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self>, keyFields?: { id1?: string, id2?: string } }): Promise<CloesceResult<Self | null>> {
+        export async function get(env: { my_kv: Env["my_kv"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self>, keyFields?: { id1?: string, id2?: string } }): Promise<CloesceResult<Self | null>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).get<Self>(Meta, args.query, args.include, args.keyFields ?? {});
         }
 
-        export async function list(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<ModelWithKv.Self[]>> {
+        export async function list(env: { my_kv: Env["my_kv"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<ModelWithKv.Self[]>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).list<Self>(Meta, args.query, args.include);
         }
@@ -406,7 +398,7 @@ export namespace ModelWithKv {
             return CloesceOrm.map<Self>(Meta, result, Source.Default.include);
         }
 
-        export async function hydrate(env: Env, base: DeepPartial<Self>, id1: string, id2: string, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
+        export async function hydrate(env: { my_kv: Env["my_kv"] }, base: DeepPartial<Self>, id1: string, id2: string, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
             return await CloesceOrm.fromEnv(env).hydrate<Self>(Meta, base, { id1, id2 }, include);
         }
     }
@@ -432,7 +424,6 @@ export namespace ModelWithR2 {
     }
 
     export interface Api {
-
         hasR2ParamAndRes(
             self: ModelWithR2.Self,
             input: R2ObjectBody,
@@ -447,23 +438,23 @@ export namespace ModelWithR2 {
     export namespace Source {
         export const Default = {
             include: {"fileData":{},"manyFileDatas":{}},
-            async get(env: Env, id: string): Promise<ModelWithR2.Self | null> {
+            async get(env: { my_r2: Env["my_r2"] }, id: string): Promise<ModelWithR2.Self | null> {
                 return await CloesceOrm.fromEnv(env).get<ModelWithR2.Self>(ModelWithR2.Meta, null, ModelWithR2.Source.Default.include, { id });
             },
         }
     }
 
     export namespace Orm {
-        export async function save(env: Env, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
+        export async function save(env: { my_r2: Env["my_r2"] }, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
             return await CloesceOrm.fromEnv(env).upsert<Self>(Meta, newModel, include);
         }
 
-        export async function get(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self>, keyFields?: { id?: string } }): Promise<CloesceResult<Self | null>> {
+        export async function get(env: { my_r2: Env["my_r2"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self>, keyFields?: { id?: string } }): Promise<CloesceResult<Self | null>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).get<Self>(Meta, args.query, args.include, args.keyFields ?? {});
         }
 
-        export async function list(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<ModelWithR2.Self[]>> {
+        export async function list(env: { my_r2: Env["my_r2"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<ModelWithR2.Self[]>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).list<Self>(Meta, args.query, args.include);
         }
@@ -476,7 +467,7 @@ export namespace ModelWithR2 {
             return CloesceOrm.map<Self>(Meta, result, Source.Default.include);
         }
 
-        export async function hydrate(env: Env, base: DeepPartial<Self>, id: string, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
+        export async function hydrate(env: { my_r2: Env["my_r2"] }, base: DeepPartial<Self>, id: string, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
             return await CloesceOrm.fromEnv(env).hydrate<Self>(Meta, base, { id }, include);
         }
     }
@@ -505,28 +496,28 @@ export namespace OneToManyModel {
     export namespace Source {
         export const Default = {
             include: {"oneToManyNav":{}},
-            getQuery: (env: Env, id: number) => env.db.prepare(`SELECT "OneToManyModel"."id" AS "id", "BasicModel_1"."id" AS "oneToManyNav.id", "BasicModel_1"."fk_to_model" AS "oneToManyNav.fk_to_model" FROM "OneToManyModel" LEFT JOIN "BasicModel" AS "BasicModel_1" ON "OneToManyModel"."id" = "BasicModel_1"."fk_to_model" WHERE "OneToManyModel"."id" = ?1`).bind(id),
-            async get(env: Env, id: number): Promise<CloesceResult<OneToManyModel.Self | null>> {
+            getQuery: (env: { db: Env["db"] }, id: number) => env.db.prepare(`SELECT "OneToManyModel"."id" AS "id", "BasicModel_1"."id" AS "oneToManyNav.id", "BasicModel_1"."fk_to_model" AS "oneToManyNav.fk_to_model" FROM "OneToManyModel" LEFT JOIN "BasicModel" AS "BasicModel_1" ON "OneToManyModel"."id" = "BasicModel_1"."fk_to_model" WHERE "OneToManyModel"."id" = ?1`).bind(id),
+            async get(env: { db: Env["db"] }, id: number): Promise<CloesceResult<OneToManyModel.Self | null>> {
                 return await CloesceOrm.fromEnv(env).get<OneToManyModel.Self>(OneToManyModel.Meta, OneToManyModel.Source.Default.getQuery(env, id), OneToManyModel.Source.Default.include, {  });
             },
-            listQuery: (env: Env, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "OneToManyModel"."id" AS "id", "BasicModel_1"."id" AS "oneToManyNav.id", "BasicModel_1"."fk_to_model" AS "oneToManyNav.fk_to_model" FROM "OneToManyModel" LEFT JOIN "BasicModel" AS "BasicModel_1" ON "OneToManyModel"."id" = "BasicModel_1"."fk_to_model" WHERE "OneToManyModel"."id" > ?1 ORDER BY "OneToManyModel"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
-            async list(env: Env, lastSeen_id: number, limit: number): Promise<CloesceResult<OneToManyModel.Self[]>> {
+            listQuery: (env: { db: Env["db"] }, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "OneToManyModel"."id" AS "id", "BasicModel_1"."id" AS "oneToManyNav.id", "BasicModel_1"."fk_to_model" AS "oneToManyNav.fk_to_model" FROM "OneToManyModel" LEFT JOIN "BasicModel" AS "BasicModel_1" ON "OneToManyModel"."id" = "BasicModel_1"."fk_to_model" WHERE "OneToManyModel"."id" > ?1 ORDER BY "OneToManyModel"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
+            async list(env: { db: Env["db"] }, lastSeen_id: number, limit: number): Promise<CloesceResult<OneToManyModel.Self[]>> {
                 return await CloesceOrm.fromEnv(env).list<OneToManyModel.Self>(OneToManyModel.Meta, OneToManyModel.Source.Default.listQuery(env, lastSeen_id, limit), OneToManyModel.Source.Default.include);
             },
         }
     }
 
     export namespace Orm {
-        export async function save(env: Env, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
+        export async function save(env: { db: Env["db"] }, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
             return await CloesceOrm.fromEnv(env).upsert<Self>(Meta, newModel, include);
         }
 
-        export async function get(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Self | null>> {
+        export async function get(env: { db: Env["db"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Self | null>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).get<Self>(Meta, args.query, args.include, {});
         }
 
-        export async function list(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<OneToManyModel.Self[]>> {
+        export async function list(env: { db: Env["db"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<OneToManyModel.Self[]>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).list<Self>(Meta, args.query, args.include);
         }
@@ -539,7 +530,7 @@ export namespace OneToManyModel {
             return CloesceOrm.map<Self>(Meta, result, Source.Default.include);
         }
 
-        export async function hydrate(env: Env, base: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
+        export async function hydrate(env: { db: Env["db"] }, base: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
             return await CloesceOrm.fromEnv(env).hydrate<Self>(Meta, base, {  }, include);
         }
     }
@@ -568,7 +559,6 @@ export namespace ToyotaPrius {
     }
 
     export interface Api {
-
         instanceMethod(
             self: ToyotaPrius.Self,
             input: string,
@@ -583,50 +573,50 @@ export namespace ToyotaPrius {
     export namespace Source {
         export const Default = {
             include: {"metadata":{},"photoData":{}},
-            getQuery: (env: Env, id: number) => env.db.prepare(`SELECT "ToyotaPrius"."id" AS "id", "ToyotaPrius"."ownerId" AS "ownerId", "ToyotaPrius"."modelYear" AS "modelYear" FROM "ToyotaPrius" WHERE "ToyotaPrius"."id" = ?1`).bind(id),
-            async get(env: Env, id: number, someKey: string): Promise<CloesceResult<ToyotaPrius.Self | null>> {
+            getQuery: (env: { db: Env["db"], my_kv: Env["my_kv"], my_r2: Env["my_r2"] }, id: number) => env.db.prepare(`SELECT "ToyotaPrius"."id" AS "id", "ToyotaPrius"."ownerId" AS "ownerId", "ToyotaPrius"."modelYear" AS "modelYear" FROM "ToyotaPrius" WHERE "ToyotaPrius"."id" = ?1`).bind(id),
+            async get(env: { db: Env["db"], my_kv: Env["my_kv"], my_r2: Env["my_r2"] }, id: number, someKey: string): Promise<CloesceResult<ToyotaPrius.Self | null>> {
                 return await CloesceOrm.fromEnv(env).get<ToyotaPrius.Self>(ToyotaPrius.Meta, ToyotaPrius.Source.Default.getQuery(env, id), ToyotaPrius.Source.Default.include, { someKey });
             },
-            listQuery: (env: Env, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "ToyotaPrius"."id" AS "id", "ToyotaPrius"."ownerId" AS "ownerId", "ToyotaPrius"."modelYear" AS "modelYear" FROM "ToyotaPrius" WHERE "ToyotaPrius"."id" > ?1 ORDER BY "ToyotaPrius"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
-            async list(env: Env, lastSeen_id: number, limit: number): Promise<CloesceResult<ToyotaPrius.Self[]>> {
+            listQuery: (env: { db: Env["db"], my_kv: Env["my_kv"], my_r2: Env["my_r2"] }, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "ToyotaPrius"."id" AS "id", "ToyotaPrius"."ownerId" AS "ownerId", "ToyotaPrius"."modelYear" AS "modelYear" FROM "ToyotaPrius" WHERE "ToyotaPrius"."id" > ?1 ORDER BY "ToyotaPrius"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
+            async list(env: { db: Env["db"], my_kv: Env["my_kv"], my_r2: Env["my_r2"] }, lastSeen_id: number, limit: number): Promise<CloesceResult<ToyotaPrius.Self[]>> {
                 return await CloesceOrm.fromEnv(env).list<ToyotaPrius.Self>(ToyotaPrius.Meta, ToyotaPrius.Source.Default.listQuery(env, lastSeen_id, limit), ToyotaPrius.Source.Default.include);
             },
         }
         export const WithKv = {
             include: {"metadata":{}},
-            getQuery: (env: Env, id: number) => env.db.prepare(`SELECT "ToyotaPrius"."id" AS "id", "ToyotaPrius"."ownerId" AS "ownerId", "ToyotaPrius"."modelYear" AS "modelYear" FROM "ToyotaPrius" WHERE "ToyotaPrius"."id" = ?1`).bind(id),
-            async get(env: Env, id: number, someKey: string): Promise<CloesceResult<ToyotaPrius.Self | null>> {
+            getQuery: (env: { db: Env["db"], my_kv: Env["my_kv"] }, id: number) => env.db.prepare(`SELECT "ToyotaPrius"."id" AS "id", "ToyotaPrius"."ownerId" AS "ownerId", "ToyotaPrius"."modelYear" AS "modelYear" FROM "ToyotaPrius" WHERE "ToyotaPrius"."id" = ?1`).bind(id),
+            async get(env: { db: Env["db"], my_kv: Env["my_kv"] }, id: number, someKey: string): Promise<CloesceResult<ToyotaPrius.Self | null>> {
                 return await CloesceOrm.fromEnv(env).get<ToyotaPrius.Self>(ToyotaPrius.Meta, ToyotaPrius.Source.WithKv.getQuery(env, id), ToyotaPrius.Source.WithKv.include, { someKey });
             },
-            listQuery: (env: Env, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "ToyotaPrius"."id" AS "id", "ToyotaPrius"."ownerId" AS "ownerId", "ToyotaPrius"."modelYear" AS "modelYear" FROM "ToyotaPrius" WHERE "ToyotaPrius"."id" > ?1 ORDER BY "ToyotaPrius"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
-            async list(env: Env, lastSeen_id: number, limit: number): Promise<CloesceResult<ToyotaPrius.Self[]>> {
+            listQuery: (env: { db: Env["db"], my_kv: Env["my_kv"] }, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "ToyotaPrius"."id" AS "id", "ToyotaPrius"."ownerId" AS "ownerId", "ToyotaPrius"."modelYear" AS "modelYear" FROM "ToyotaPrius" WHERE "ToyotaPrius"."id" > ?1 ORDER BY "ToyotaPrius"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
+            async list(env: { db: Env["db"], my_kv: Env["my_kv"] }, lastSeen_id: number, limit: number): Promise<CloesceResult<ToyotaPrius.Self[]>> {
                 return await CloesceOrm.fromEnv(env).list<ToyotaPrius.Self>(ToyotaPrius.Meta, ToyotaPrius.Source.WithKv.listQuery(env, lastSeen_id, limit), ToyotaPrius.Source.WithKv.include);
             },
         }
         export const WithR2 = {
             include: {"photoData":{}},
-            getQuery: (env: Env, id: number) => env.db.prepare(`SELECT "ToyotaPrius"."id" AS "id", "ToyotaPrius"."ownerId" AS "ownerId", "ToyotaPrius"."modelYear" AS "modelYear" FROM "ToyotaPrius" WHERE "ToyotaPrius"."id" = ?1`).bind(id),
-            async get(env: Env, id: number, someKey: string): Promise<CloesceResult<ToyotaPrius.Self | null>> {
+            getQuery: (env: { db: Env["db"], my_r2: Env["my_r2"] }, id: number) => env.db.prepare(`SELECT "ToyotaPrius"."id" AS "id", "ToyotaPrius"."ownerId" AS "ownerId", "ToyotaPrius"."modelYear" AS "modelYear" FROM "ToyotaPrius" WHERE "ToyotaPrius"."id" = ?1`).bind(id),
+            async get(env: { db: Env["db"], my_r2: Env["my_r2"] }, id: number, someKey: string): Promise<CloesceResult<ToyotaPrius.Self | null>> {
                 return await CloesceOrm.fromEnv(env).get<ToyotaPrius.Self>(ToyotaPrius.Meta, ToyotaPrius.Source.WithR2.getQuery(env, id), ToyotaPrius.Source.WithR2.include, { someKey });
             },
-            listQuery: (env: Env, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "ToyotaPrius"."id" AS "id", "ToyotaPrius"."ownerId" AS "ownerId", "ToyotaPrius"."modelYear" AS "modelYear" FROM "ToyotaPrius" WHERE "ToyotaPrius"."id" > ?1 ORDER BY "ToyotaPrius"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
-            async list(env: Env, lastSeen_id: number, limit: number): Promise<CloesceResult<ToyotaPrius.Self[]>> {
+            listQuery: (env: { db: Env["db"], my_r2: Env["my_r2"] }, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "ToyotaPrius"."id" AS "id", "ToyotaPrius"."ownerId" AS "ownerId", "ToyotaPrius"."modelYear" AS "modelYear" FROM "ToyotaPrius" WHERE "ToyotaPrius"."id" > ?1 ORDER BY "ToyotaPrius"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
+            async list(env: { db: Env["db"], my_r2: Env["my_r2"] }, lastSeen_id: number, limit: number): Promise<CloesceResult<ToyotaPrius.Self[]>> {
                 return await CloesceOrm.fromEnv(env).list<ToyotaPrius.Self>(ToyotaPrius.Meta, ToyotaPrius.Source.WithR2.listQuery(env, lastSeen_id, limit), ToyotaPrius.Source.WithR2.include);
             },
         }
     }
 
     export namespace Orm {
-        export async function save(env: Env, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
+        export async function save(env: { db: Env["db"], my_kv: Env["my_kv"], my_r2: Env["my_r2"] }, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
             return await CloesceOrm.fromEnv(env).upsert<Self>(Meta, newModel, include);
         }
 
-        export async function get(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self>, keyFields?: { someKey?: string } }): Promise<CloesceResult<Self | null>> {
+        export async function get(env: { db: Env["db"], my_kv: Env["my_kv"], my_r2: Env["my_r2"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self>, keyFields?: { someKey?: string } }): Promise<CloesceResult<Self | null>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).get<Self>(Meta, args.query, args.include, args.keyFields ?? {});
         }
 
-        export async function list(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<ToyotaPrius.Self[]>> {
+        export async function list(env: { db: Env["db"], my_kv: Env["my_kv"], my_r2: Env["my_r2"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<ToyotaPrius.Self[]>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).list<Self>(Meta, args.query, args.include);
         }
@@ -639,7 +629,7 @@ export namespace ToyotaPrius {
             return CloesceOrm.map<Self>(Meta, result, Source.Default.include);
         }
 
-        export async function hydrate(env: Env, base: DeepPartial<Self>, someKey: string, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
+        export async function hydrate(env: { db: Env["db"], my_kv: Env["my_kv"], my_r2: Env["my_r2"] }, base: DeepPartial<Self>, someKey: string, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
             return await CloesceOrm.fromEnv(env).hydrate<Self>(Meta, base, { someKey }, include);
         }
     }
@@ -668,28 +658,28 @@ export namespace BasicModel {
     export namespace Source {
         export const Default = {
             include: {},
-            getQuery: (env: Env, id: number) => env.db.prepare(`SELECT "BasicModel"."id" AS "id", "BasicModel"."fk_to_model" AS "fk_to_model" FROM "BasicModel" WHERE "BasicModel"."id" = ?1`).bind(id),
-            async get(env: Env, id: number): Promise<CloesceResult<BasicModel.Self | null>> {
+            getQuery: (env: { db: Env["db"] }, id: number) => env.db.prepare(`SELECT "BasicModel"."id" AS "id", "BasicModel"."fk_to_model" AS "fk_to_model" FROM "BasicModel" WHERE "BasicModel"."id" = ?1`).bind(id),
+            async get(env: { db: Env["db"] }, id: number): Promise<CloesceResult<BasicModel.Self | null>> {
                 return await CloesceOrm.fromEnv(env).get<BasicModel.Self>(BasicModel.Meta, BasicModel.Source.Default.getQuery(env, id), BasicModel.Source.Default.include, {  });
             },
-            listQuery: (env: Env, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "BasicModel"."id" AS "id", "BasicModel"."fk_to_model" AS "fk_to_model" FROM "BasicModel" WHERE "BasicModel"."id" > ?1 ORDER BY "BasicModel"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
-            async list(env: Env, lastSeen_id: number, limit: number): Promise<CloesceResult<BasicModel.Self[]>> {
+            listQuery: (env: { db: Env["db"] }, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "BasicModel"."id" AS "id", "BasicModel"."fk_to_model" AS "fk_to_model" FROM "BasicModel" WHERE "BasicModel"."id" > ?1 ORDER BY "BasicModel"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
+            async list(env: { db: Env["db"] }, lastSeen_id: number, limit: number): Promise<CloesceResult<BasicModel.Self[]>> {
                 return await CloesceOrm.fromEnv(env).list<BasicModel.Self>(BasicModel.Meta, BasicModel.Source.Default.listQuery(env, lastSeen_id, limit), BasicModel.Source.Default.include);
             },
         }
     }
 
     export namespace Orm {
-        export async function save(env: Env, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
+        export async function save(env: { db: Env["db"] }, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
             return await CloesceOrm.fromEnv(env).upsert<Self>(Meta, newModel, include);
         }
 
-        export async function get(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Self | null>> {
+        export async function get(env: { db: Env["db"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Self | null>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).get<Self>(Meta, args.query, args.include, {});
         }
 
-        export async function list(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<BasicModel.Self[]>> {
+        export async function list(env: { db: Env["db"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<BasicModel.Self[]>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).list<Self>(Meta, args.query, args.include);
         }
@@ -702,7 +692,7 @@ export namespace BasicModel {
             return CloesceOrm.map<Self>(Meta, result, Source.Default.include);
         }
 
-        export async function hydrate(env: Env, base: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
+        export async function hydrate(env: { db: Env["db"] }, base: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
             return await CloesceOrm.fromEnv(env).hydrate<Self>(Meta, base, {  }, include);
         }
     }
@@ -727,7 +717,6 @@ export namespace ModelWithCustomDs {
     }
 
     export interface Api {
-
         instanceMethod(
             self: ModelWithCustomDs.Self,
             input: string,
@@ -742,39 +731,39 @@ export namespace ModelWithCustomDs {
     export namespace Source {
         export const Custom = {
             include: {"data":{},"oneToManyModel":{"oneToManyNav":{}}},
-            getQuery: (env: Env, id: number, externalParam: string) => env.db.prepare(`SELECT * FROM ModelWithCustomDs WHERE id = ?1 AND name LIKE ?2`).bind(id, externalParam),
-            async get(env: Env, id: number, externalParam: string): Promise<CloesceResult<ModelWithCustomDs.Self | null>> {
+            getQuery: (env: { db: Env["db"], my_r2: Env["my_r2"] }, id: number, externalParam: string) => env.db.prepare(`SELECT * FROM ModelWithCustomDs WHERE id = ?1 AND name LIKE ?2`).bind(id, externalParam),
+            async get(env: { db: Env["db"], my_r2: Env["my_r2"] }, id: number, externalParam: string): Promise<CloesceResult<ModelWithCustomDs.Self | null>> {
                 return await CloesceOrm.fromEnv(env).get<ModelWithCustomDs.Self>(ModelWithCustomDs.Meta, ModelWithCustomDs.Source.Custom.getQuery(env, id, externalParam), ModelWithCustomDs.Source.Custom.include, {  });
             },
-            listQuery: (env: Env, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "ModelWithCustomDs"."id" AS "id", "ModelWithCustomDs"."name" AS "name", "ModelWithCustomDs"."oneToManyId" AS "oneToManyId", "OneToManyModel_1"."id" AS "oneToManyModel.id", "BasicModel_2"."id" AS "oneToManyModel.oneToManyNav.id", "BasicModel_2"."fk_to_model" AS "oneToManyModel.oneToManyNav.fk_to_model" FROM "ModelWithCustomDs" LEFT JOIN "OneToManyModel" AS "OneToManyModel_1" ON "ModelWithCustomDs"."oneToManyId" = "OneToManyModel_1"."id" LEFT JOIN "BasicModel" AS "BasicModel_2" ON "OneToManyModel_1"."id" = "BasicModel_2"."fk_to_model" WHERE "ModelWithCustomDs"."id" > ?1 ORDER BY "ModelWithCustomDs"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
-            async list(env: Env, lastSeen_id: number, limit: number): Promise<CloesceResult<ModelWithCustomDs.Self[]>> {
+            listQuery: (env: { db: Env["db"], my_r2: Env["my_r2"] }, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "ModelWithCustomDs"."id" AS "id", "ModelWithCustomDs"."name" AS "name", "ModelWithCustomDs"."oneToManyId" AS "oneToManyId", "OneToManyModel_1"."id" AS "oneToManyModel.id", "BasicModel_2"."id" AS "oneToManyModel.oneToManyNav.id", "BasicModel_2"."fk_to_model" AS "oneToManyModel.oneToManyNav.fk_to_model" FROM "ModelWithCustomDs" LEFT JOIN "OneToManyModel" AS "OneToManyModel_1" ON "ModelWithCustomDs"."oneToManyId" = "OneToManyModel_1"."id" LEFT JOIN "BasicModel" AS "BasicModel_2" ON "OneToManyModel_1"."id" = "BasicModel_2"."fk_to_model" WHERE "ModelWithCustomDs"."id" > ?1 ORDER BY "ModelWithCustomDs"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
+            async list(env: { db: Env["db"], my_r2: Env["my_r2"] }, lastSeen_id: number, limit: number): Promise<CloesceResult<ModelWithCustomDs.Self[]>> {
                 return await CloesceOrm.fromEnv(env).list<ModelWithCustomDs.Self>(ModelWithCustomDs.Meta, ModelWithCustomDs.Source.Custom.listQuery(env, lastSeen_id, limit), ModelWithCustomDs.Source.Custom.include);
             },
         }
         export const Default = {
             include: {"data":{},"oneToManyModel":{"oneToManyNav":{}}},
-            getQuery: (env: Env, id: number) => env.db.prepare(`SELECT "ModelWithCustomDs"."id" AS "id", "ModelWithCustomDs"."name" AS "name", "ModelWithCustomDs"."oneToManyId" AS "oneToManyId", "OneToManyModel_1"."id" AS "oneToManyModel.id", "BasicModel_2"."id" AS "oneToManyModel.oneToManyNav.id", "BasicModel_2"."fk_to_model" AS "oneToManyModel.oneToManyNav.fk_to_model" FROM "ModelWithCustomDs" LEFT JOIN "OneToManyModel" AS "OneToManyModel_1" ON "ModelWithCustomDs"."oneToManyId" = "OneToManyModel_1"."id" LEFT JOIN "BasicModel" AS "BasicModel_2" ON "OneToManyModel_1"."id" = "BasicModel_2"."fk_to_model" WHERE "ModelWithCustomDs"."id" = ?1`).bind(id),
-            async get(env: Env, id: number): Promise<CloesceResult<ModelWithCustomDs.Self | null>> {
+            getQuery: (env: { db: Env["db"], my_r2: Env["my_r2"] }, id: number) => env.db.prepare(`SELECT "ModelWithCustomDs"."id" AS "id", "ModelWithCustomDs"."name" AS "name", "ModelWithCustomDs"."oneToManyId" AS "oneToManyId", "OneToManyModel_1"."id" AS "oneToManyModel.id", "BasicModel_2"."id" AS "oneToManyModel.oneToManyNav.id", "BasicModel_2"."fk_to_model" AS "oneToManyModel.oneToManyNav.fk_to_model" FROM "ModelWithCustomDs" LEFT JOIN "OneToManyModel" AS "OneToManyModel_1" ON "ModelWithCustomDs"."oneToManyId" = "OneToManyModel_1"."id" LEFT JOIN "BasicModel" AS "BasicModel_2" ON "OneToManyModel_1"."id" = "BasicModel_2"."fk_to_model" WHERE "ModelWithCustomDs"."id" = ?1`).bind(id),
+            async get(env: { db: Env["db"], my_r2: Env["my_r2"] }, id: number): Promise<CloesceResult<ModelWithCustomDs.Self | null>> {
                 return await CloesceOrm.fromEnv(env).get<ModelWithCustomDs.Self>(ModelWithCustomDs.Meta, ModelWithCustomDs.Source.Default.getQuery(env, id), ModelWithCustomDs.Source.Default.include, {  });
             },
-            listQuery: (env: Env, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "ModelWithCustomDs"."id" AS "id", "ModelWithCustomDs"."name" AS "name", "ModelWithCustomDs"."oneToManyId" AS "oneToManyId", "OneToManyModel_1"."id" AS "oneToManyModel.id", "BasicModel_2"."id" AS "oneToManyModel.oneToManyNav.id", "BasicModel_2"."fk_to_model" AS "oneToManyModel.oneToManyNav.fk_to_model" FROM "ModelWithCustomDs" LEFT JOIN "OneToManyModel" AS "OneToManyModel_1" ON "ModelWithCustomDs"."oneToManyId" = "OneToManyModel_1"."id" LEFT JOIN "BasicModel" AS "BasicModel_2" ON "OneToManyModel_1"."id" = "BasicModel_2"."fk_to_model" WHERE "ModelWithCustomDs"."id" > ?1 ORDER BY "ModelWithCustomDs"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
-            async list(env: Env, lastSeen_id: number, limit: number): Promise<CloesceResult<ModelWithCustomDs.Self[]>> {
+            listQuery: (env: { db: Env["db"], my_r2: Env["my_r2"] }, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "ModelWithCustomDs"."id" AS "id", "ModelWithCustomDs"."name" AS "name", "ModelWithCustomDs"."oneToManyId" AS "oneToManyId", "OneToManyModel_1"."id" AS "oneToManyModel.id", "BasicModel_2"."id" AS "oneToManyModel.oneToManyNav.id", "BasicModel_2"."fk_to_model" AS "oneToManyModel.oneToManyNav.fk_to_model" FROM "ModelWithCustomDs" LEFT JOIN "OneToManyModel" AS "OneToManyModel_1" ON "ModelWithCustomDs"."oneToManyId" = "OneToManyModel_1"."id" LEFT JOIN "BasicModel" AS "BasicModel_2" ON "OneToManyModel_1"."id" = "BasicModel_2"."fk_to_model" WHERE "ModelWithCustomDs"."id" > ?1 ORDER BY "ModelWithCustomDs"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
+            async list(env: { db: Env["db"], my_r2: Env["my_r2"] }, lastSeen_id: number, limit: number): Promise<CloesceResult<ModelWithCustomDs.Self[]>> {
                 return await CloesceOrm.fromEnv(env).list<ModelWithCustomDs.Self>(ModelWithCustomDs.Meta, ModelWithCustomDs.Source.Default.listQuery(env, lastSeen_id, limit), ModelWithCustomDs.Source.Default.include);
             },
         }
     }
 
     export namespace Orm {
-        export async function save(env: Env, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
+        export async function save(env: { db: Env["db"], my_r2: Env["my_r2"] }, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
             return await CloesceOrm.fromEnv(env).upsert<Self>(Meta, newModel, include);
         }
 
-        export async function get(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Self | null>> {
+        export async function get(env: { db: Env["db"], my_r2: Env["my_r2"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Self | null>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).get<Self>(Meta, args.query, args.include, {});
         }
 
-        export async function list(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<ModelWithCustomDs.Self[]>> {
+        export async function list(env: { db: Env["db"], my_r2: Env["my_r2"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<ModelWithCustomDs.Self[]>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).list<Self>(Meta, args.query, args.include);
         }
@@ -787,7 +776,7 @@ export namespace ModelWithCustomDs {
             return CloesceOrm.map<Self>(Meta, result, Source.Default.include);
         }
 
-        export async function hydrate(env: Env, base: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
+        export async function hydrate(env: { db: Env["db"], my_r2: Env["my_r2"] }, base: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
             return await CloesceOrm.fromEnv(env).hydrate<Self>(Meta, base, {  }, include);
         }
     }
@@ -817,28 +806,28 @@ export namespace HasOneToOne {
     export namespace Source {
         export const Default = {
             include: {"oneToOneNav":{}},
-            getQuery: (env: Env, id: number) => env.db.prepare(`SELECT "HasOneToOne"."id" AS "id", "HasOneToOne"."basicModelId" AS "basicModelId", "BasicModel_1"."id" AS "oneToOneNav.id", "BasicModel_1"."fk_to_model" AS "oneToOneNav.fk_to_model" FROM "HasOneToOne" LEFT JOIN "BasicModel" AS "BasicModel_1" ON "HasOneToOne"."basicModelId" = "BasicModel_1"."id" WHERE "HasOneToOne"."id" = ?1`).bind(id),
-            async get(env: Env, id: number): Promise<CloesceResult<HasOneToOne.Self | null>> {
+            getQuery: (env: { db: Env["db"] }, id: number) => env.db.prepare(`SELECT "HasOneToOne"."id" AS "id", "HasOneToOne"."basicModelId" AS "basicModelId", "BasicModel_1"."id" AS "oneToOneNav.id", "BasicModel_1"."fk_to_model" AS "oneToOneNav.fk_to_model" FROM "HasOneToOne" LEFT JOIN "BasicModel" AS "BasicModel_1" ON "HasOneToOne"."basicModelId" = "BasicModel_1"."id" WHERE "HasOneToOne"."id" = ?1`).bind(id),
+            async get(env: { db: Env["db"] }, id: number): Promise<CloesceResult<HasOneToOne.Self | null>> {
                 return await CloesceOrm.fromEnv(env).get<HasOneToOne.Self>(HasOneToOne.Meta, HasOneToOne.Source.Default.getQuery(env, id), HasOneToOne.Source.Default.include, {  });
             },
-            listQuery: (env: Env, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "HasOneToOne"."id" AS "id", "HasOneToOne"."basicModelId" AS "basicModelId", "BasicModel_1"."id" AS "oneToOneNav.id", "BasicModel_1"."fk_to_model" AS "oneToOneNav.fk_to_model" FROM "HasOneToOne" LEFT JOIN "BasicModel" AS "BasicModel_1" ON "HasOneToOne"."basicModelId" = "BasicModel_1"."id" WHERE "HasOneToOne"."id" > ?1 ORDER BY "HasOneToOne"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
-            async list(env: Env, lastSeen_id: number, limit: number): Promise<CloesceResult<HasOneToOne.Self[]>> {
+            listQuery: (env: { db: Env["db"] }, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "HasOneToOne"."id" AS "id", "HasOneToOne"."basicModelId" AS "basicModelId", "BasicModel_1"."id" AS "oneToOneNav.id", "BasicModel_1"."fk_to_model" AS "oneToOneNav.fk_to_model" FROM "HasOneToOne" LEFT JOIN "BasicModel" AS "BasicModel_1" ON "HasOneToOne"."basicModelId" = "BasicModel_1"."id" WHERE "HasOneToOne"."id" > ?1 ORDER BY "HasOneToOne"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
+            async list(env: { db: Env["db"] }, lastSeen_id: number, limit: number): Promise<CloesceResult<HasOneToOne.Self[]>> {
                 return await CloesceOrm.fromEnv(env).list<HasOneToOne.Self>(HasOneToOne.Meta, HasOneToOne.Source.Default.listQuery(env, lastSeen_id, limit), HasOneToOne.Source.Default.include);
             },
         }
     }
 
     export namespace Orm {
-        export async function save(env: Env, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
+        export async function save(env: { db: Env["db"] }, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
             return await CloesceOrm.fromEnv(env).upsert<Self>(Meta, newModel, include);
         }
 
-        export async function get(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Self | null>> {
+        export async function get(env: { db: Env["db"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Self | null>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).get<Self>(Meta, args.query, args.include, {});
         }
 
-        export async function list(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<HasOneToOne.Self[]>> {
+        export async function list(env: { db: Env["db"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<HasOneToOne.Self[]>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).list<Self>(Meta, args.query, args.include);
         }
@@ -851,7 +840,7 @@ export namespace HasOneToOne {
             return CloesceOrm.map<Self>(Meta, result, Source.Default.include);
         }
 
-        export async function hydrate(env: Env, base: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
+        export async function hydrate(env: { db: Env["db"] }, base: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
             return await CloesceOrm.fromEnv(env).hydrate<Self>(Meta, base, {  }, include);
         }
     }
@@ -881,39 +870,39 @@ export namespace ModelWithCruds {
     export namespace Source {
         export const ByName = {
             include: {},
-            getQuery: (env: Env, name: string) => env.db.prepare(`SELECT * FROM ModelWithCruds WHERE name = ?1`).bind(name),
-            async get(env: Env, name: string): Promise<CloesceResult<ModelWithCruds.Self | null>> {
+            getQuery: (env: { db: Env["db"] }, name: string) => env.db.prepare(`SELECT * FROM ModelWithCruds WHERE name = ?1`).bind(name),
+            async get(env: { db: Env["db"] }, name: string): Promise<CloesceResult<ModelWithCruds.Self | null>> {
                 return await CloesceOrm.fromEnv(env).get<ModelWithCruds.Self>(ModelWithCruds.Meta, ModelWithCruds.Source.ByName.getQuery(env, name), ModelWithCruds.Source.ByName.include, {  });
             },
-            listQuery: (env: Env, name: string, limit: number) => env.db.prepare(`SELECT * FROM ModelWithCruds WHERE name LIKE ?1 LIMIT ?2`).bind(name, limit),
-            async list(env: Env, name: string, limit: number): Promise<CloesceResult<ModelWithCruds.Self[]>> {
+            listQuery: (env: { db: Env["db"] }, name: string, limit: number) => env.db.prepare(`SELECT * FROM ModelWithCruds WHERE name LIKE ?1 LIMIT ?2`).bind(name, limit),
+            async list(env: { db: Env["db"] }, name: string, limit: number): Promise<CloesceResult<ModelWithCruds.Self[]>> {
                 return await CloesceOrm.fromEnv(env).list<ModelWithCruds.Self>(ModelWithCruds.Meta, ModelWithCruds.Source.ByName.listQuery(env, name, limit), ModelWithCruds.Source.ByName.include);
             },
         }
         export const Default = {
             include: {},
-            getQuery: (env: Env, id: number) => env.db.prepare(`SELECT "ModelWithCruds"."id" AS "id", "ModelWithCruds"."name" AS "name", "ModelWithCruds"."categoryId" AS "categoryId" FROM "ModelWithCruds" WHERE "ModelWithCruds"."id" = ?1`).bind(id),
-            async get(env: Env, id: number): Promise<CloesceResult<ModelWithCruds.Self | null>> {
+            getQuery: (env: { db: Env["db"] }, id: number) => env.db.prepare(`SELECT "ModelWithCruds"."id" AS "id", "ModelWithCruds"."name" AS "name", "ModelWithCruds"."categoryId" AS "categoryId" FROM "ModelWithCruds" WHERE "ModelWithCruds"."id" = ?1`).bind(id),
+            async get(env: { db: Env["db"] }, id: number): Promise<CloesceResult<ModelWithCruds.Self | null>> {
                 return await CloesceOrm.fromEnv(env).get<ModelWithCruds.Self>(ModelWithCruds.Meta, ModelWithCruds.Source.Default.getQuery(env, id), ModelWithCruds.Source.Default.include, {  });
             },
-            listQuery: (env: Env, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "ModelWithCruds"."id" AS "id", "ModelWithCruds"."name" AS "name", "ModelWithCruds"."categoryId" AS "categoryId" FROM "ModelWithCruds" WHERE "ModelWithCruds"."id" > ?1 ORDER BY "ModelWithCruds"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
-            async list(env: Env, lastSeen_id: number, limit: number): Promise<CloesceResult<ModelWithCruds.Self[]>> {
+            listQuery: (env: { db: Env["db"] }, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "ModelWithCruds"."id" AS "id", "ModelWithCruds"."name" AS "name", "ModelWithCruds"."categoryId" AS "categoryId" FROM "ModelWithCruds" WHERE "ModelWithCruds"."id" > ?1 ORDER BY "ModelWithCruds"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
+            async list(env: { db: Env["db"] }, lastSeen_id: number, limit: number): Promise<CloesceResult<ModelWithCruds.Self[]>> {
                 return await CloesceOrm.fromEnv(env).list<ModelWithCruds.Self>(ModelWithCruds.Meta, ModelWithCruds.Source.Default.listQuery(env, lastSeen_id, limit), ModelWithCruds.Source.Default.include);
             },
         }
     }
 
     export namespace Orm {
-        export async function save(env: Env, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
+        export async function save(env: { db: Env["db"] }, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
             return await CloesceOrm.fromEnv(env).upsert<Self>(Meta, newModel, include);
         }
 
-        export async function get(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Self | null>> {
+        export async function get(env: { db: Env["db"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Self | null>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).get<Self>(Meta, args.query, args.include, {});
         }
 
-        export async function list(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<ModelWithCruds.Self[]>> {
+        export async function list(env: { db: Env["db"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<ModelWithCruds.Self[]>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).list<Self>(Meta, args.query, args.include);
         }
@@ -926,7 +915,7 @@ export namespace ModelWithCruds {
             return CloesceOrm.map<Self>(Meta, result, Source.Default.include);
         }
 
-        export async function hydrate(env: Env, base: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
+        export async function hydrate(env: { db: Env["db"] }, base: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
             return await CloesceOrm.fromEnv(env).hydrate<Self>(Meta, base, {  }, include);
         }
     }

--- a/tests/e2e/fixtures/adv_ds/backend.ts
+++ b/tests/e2e/fixtures/adv_ds/backend.ts
@@ -24,11 +24,9 @@ export namespace Hamburger {
     }
 
     export interface Api {
-
         noLettuceToppings(
             self: Hamburger.Self,
         ): ApiResult<Topping.Self[]>;
-
         onlyBaconToppings(
             self: Hamburger.Self,
         ): ApiResult<Topping.Self[]>;
@@ -42,61 +40,61 @@ export namespace Hamburger {
     export namespace Source {
         export const BurgersWithLettuceOrdered = {
             include: {"toppings":{}},
-            getQuery: (env: Env, id: number) => env.db.prepare(`SELECT "Hamburger"."id" AS "id", "Hamburger"."name" AS "name", "HamburgerTopping_2"."right" AS "toppings.id", "Topping_1"."name" AS "toppings.name" FROM "Hamburger" LEFT JOIN "HamburgerTopping" AS "HamburgerTopping_2" ON "Hamburger"."id" = "HamburgerTopping_2"."left" LEFT JOIN "Topping" AS "Topping_1" ON "HamburgerTopping_2"."right" = "Topping_1"."id" WHERE "Hamburger"."id" = ?1`).bind(id),
-            async get(env: Env, id: number): Promise<CloesceResult<Hamburger.Self | null>> {
+            getQuery: (env: { db: Env["db"] }, id: number) => env.db.prepare(`SELECT "Hamburger"."id" AS "id", "Hamburger"."name" AS "name", "HamburgerTopping_2"."right" AS "toppings.id", "Topping_1"."name" AS "toppings.name" FROM "Hamburger" LEFT JOIN "HamburgerTopping" AS "HamburgerTopping_2" ON "Hamburger"."id" = "HamburgerTopping_2"."left" LEFT JOIN "Topping" AS "Topping_1" ON "HamburgerTopping_2"."right" = "Topping_1"."id" WHERE "Hamburger"."id" = ?1`).bind(id),
+            async get(env: { db: Env["db"] }, id: number): Promise<CloesceResult<Hamburger.Self | null>> {
                 return await CloesceOrm.fromEnv(env).get<Hamburger.Self>(Hamburger.Meta, Hamburger.Source.BurgersWithLettuceOrdered.getQuery(env, id), Hamburger.Source.BurgersWithLettuceOrdered.include, {  });
             },
-            listQuery: (env: Env, lastId: number, limit: number) => env.db.prepare(`WITH included as (SELECT "Hamburger"."id" AS "id", "Hamburger"."name" AS "name", "HamburgerTopping_2"."right" AS "toppings.id", "Topping_1"."name" AS "toppings.name" FROM "Hamburger" LEFT JOIN "HamburgerTopping" AS "HamburgerTopping_2" ON "Hamburger"."id" = "HamburgerTopping_2"."left" LEFT JOIN "Topping" AS "Topping_1" ON "HamburgerTopping_2"."right" = "Topping_1"."id") SELECT * FROM included WHERE [toppings.name] = 'LETTUCE' AND id > ?1 ORDER BY id LIMIT ?2`).bind(lastId, limit),
-            async list(env: Env, lastId: number, limit: number): Promise<CloesceResult<Hamburger.Self[]>> {
+            listQuery: (env: { db: Env["db"] }, lastId: number, limit: number) => env.db.prepare(`WITH included as (SELECT "Hamburger"."id" AS "id", "Hamburger"."name" AS "name", "HamburgerTopping_2"."right" AS "toppings.id", "Topping_1"."name" AS "toppings.name" FROM "Hamburger" LEFT JOIN "HamburgerTopping" AS "HamburgerTopping_2" ON "Hamburger"."id" = "HamburgerTopping_2"."left" LEFT JOIN "Topping" AS "Topping_1" ON "HamburgerTopping_2"."right" = "Topping_1"."id") SELECT * FROM included WHERE [toppings.name] = 'LETTUCE' AND id > ?1 ORDER BY id LIMIT ?2`).bind(lastId, limit),
+            async list(env: { db: Env["db"] }, lastId: number, limit: number): Promise<CloesceResult<Hamburger.Self[]>> {
                 return await CloesceOrm.fromEnv(env).list<Hamburger.Self>(Hamburger.Meta, Hamburger.Source.BurgersWithLettuceOrdered.listQuery(env, lastId, limit), Hamburger.Source.BurgersWithLettuceOrdered.include);
             },
         }
         export const Default = {
             include: {"toppings":{}},
-            getQuery: (env: Env, id: number) => env.db.prepare(`SELECT "Hamburger"."id" AS "id", "Hamburger"."name" AS "name", "HamburgerTopping_2"."right" AS "toppings.id", "Topping_1"."name" AS "toppings.name" FROM "Hamburger" LEFT JOIN "HamburgerTopping" AS "HamburgerTopping_2" ON "Hamburger"."id" = "HamburgerTopping_2"."left" LEFT JOIN "Topping" AS "Topping_1" ON "HamburgerTopping_2"."right" = "Topping_1"."id" WHERE "Hamburger"."id" = ?1`).bind(id),
-            async get(env: Env, id: number): Promise<CloesceResult<Hamburger.Self | null>> {
+            getQuery: (env: { db: Env["db"] }, id: number) => env.db.prepare(`SELECT "Hamburger"."id" AS "id", "Hamburger"."name" AS "name", "HamburgerTopping_2"."right" AS "toppings.id", "Topping_1"."name" AS "toppings.name" FROM "Hamburger" LEFT JOIN "HamburgerTopping" AS "HamburgerTopping_2" ON "Hamburger"."id" = "HamburgerTopping_2"."left" LEFT JOIN "Topping" AS "Topping_1" ON "HamburgerTopping_2"."right" = "Topping_1"."id" WHERE "Hamburger"."id" = ?1`).bind(id),
+            async get(env: { db: Env["db"] }, id: number): Promise<CloesceResult<Hamburger.Self | null>> {
                 return await CloesceOrm.fromEnv(env).get<Hamburger.Self>(Hamburger.Meta, Hamburger.Source.Default.getQuery(env, id), Hamburger.Source.Default.include, {  });
             },
-            listQuery: (env: Env, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "Hamburger"."id" AS "id", "Hamburger"."name" AS "name", "HamburgerTopping_2"."right" AS "toppings.id", "Topping_1"."name" AS "toppings.name" FROM "Hamburger" LEFT JOIN "HamburgerTopping" AS "HamburgerTopping_2" ON "Hamburger"."id" = "HamburgerTopping_2"."left" LEFT JOIN "Topping" AS "Topping_1" ON "HamburgerTopping_2"."right" = "Topping_1"."id" WHERE "Hamburger"."id" > ?1 ORDER BY "Hamburger"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
-            async list(env: Env, lastSeen_id: number, limit: number): Promise<CloesceResult<Hamburger.Self[]>> {
+            listQuery: (env: { db: Env["db"] }, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "Hamburger"."id" AS "id", "Hamburger"."name" AS "name", "HamburgerTopping_2"."right" AS "toppings.id", "Topping_1"."name" AS "toppings.name" FROM "Hamburger" LEFT JOIN "HamburgerTopping" AS "HamburgerTopping_2" ON "Hamburger"."id" = "HamburgerTopping_2"."left" LEFT JOIN "Topping" AS "Topping_1" ON "HamburgerTopping_2"."right" = "Topping_1"."id" WHERE "Hamburger"."id" > ?1 ORDER BY "Hamburger"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
+            async list(env: { db: Env["db"] }, lastSeen_id: number, limit: number): Promise<CloesceResult<Hamburger.Self[]>> {
                 return await CloesceOrm.fromEnv(env).list<Hamburger.Self>(Hamburger.Meta, Hamburger.Source.Default.listQuery(env, lastSeen_id, limit), Hamburger.Source.Default.include);
             },
         }
         export const NoLettuce = {
             include: {"toppings":{}},
-            getQuery: (env: Env, id: number) => env.db.prepare(`WITH included as (SELECT "Hamburger"."id" AS "id", "Hamburger"."name" AS "name", "HamburgerTopping_2"."right" AS "toppings.id", "Topping_1"."name" AS "toppings.name" FROM "Hamburger" LEFT JOIN "HamburgerTopping" AS "HamburgerTopping_2" ON "Hamburger"."id" = "HamburgerTopping_2"."left" LEFT JOIN "Topping" AS "Topping_1" ON "HamburgerTopping_2"."right" = "Topping_1"."id") SELECT * FROM included WHERE [toppings.name] != 'LETTUCE' AND id = ?1 ORDER BY id`).bind(id),
-            async get(env: Env, id: number): Promise<CloesceResult<Hamburger.Self | null>> {
+            getQuery: (env: { db: Env["db"] }, id: number) => env.db.prepare(`WITH included as (SELECT "Hamburger"."id" AS "id", "Hamburger"."name" AS "name", "HamburgerTopping_2"."right" AS "toppings.id", "Topping_1"."name" AS "toppings.name" FROM "Hamburger" LEFT JOIN "HamburgerTopping" AS "HamburgerTopping_2" ON "Hamburger"."id" = "HamburgerTopping_2"."left" LEFT JOIN "Topping" AS "Topping_1" ON "HamburgerTopping_2"."right" = "Topping_1"."id") SELECT * FROM included WHERE [toppings.name] != 'LETTUCE' AND id = ?1 ORDER BY id`).bind(id),
+            async get(env: { db: Env["db"] }, id: number): Promise<CloesceResult<Hamburger.Self | null>> {
                 return await CloesceOrm.fromEnv(env).get<Hamburger.Self>(Hamburger.Meta, Hamburger.Source.NoLettuce.getQuery(env, id), Hamburger.Source.NoLettuce.include, {  });
             },
-            listQuery: (env: Env, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "Hamburger"."id" AS "id", "Hamburger"."name" AS "name", "HamburgerTopping_2"."right" AS "toppings.id", "Topping_1"."name" AS "toppings.name" FROM "Hamburger" LEFT JOIN "HamburgerTopping" AS "HamburgerTopping_2" ON "Hamburger"."id" = "HamburgerTopping_2"."left" LEFT JOIN "Topping" AS "Topping_1" ON "HamburgerTopping_2"."right" = "Topping_1"."id" WHERE "Hamburger"."id" > ?1 ORDER BY "Hamburger"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
-            async list(env: Env, lastSeen_id: number, limit: number): Promise<CloesceResult<Hamburger.Self[]>> {
+            listQuery: (env: { db: Env["db"] }, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "Hamburger"."id" AS "id", "Hamburger"."name" AS "name", "HamburgerTopping_2"."right" AS "toppings.id", "Topping_1"."name" AS "toppings.name" FROM "Hamburger" LEFT JOIN "HamburgerTopping" AS "HamburgerTopping_2" ON "Hamburger"."id" = "HamburgerTopping_2"."left" LEFT JOIN "Topping" AS "Topping_1" ON "HamburgerTopping_2"."right" = "Topping_1"."id" WHERE "Hamburger"."id" > ?1 ORDER BY "Hamburger"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
+            async list(env: { db: Env["db"] }, lastSeen_id: number, limit: number): Promise<CloesceResult<Hamburger.Self[]>> {
                 return await CloesceOrm.fromEnv(env).list<Hamburger.Self>(Hamburger.Meta, Hamburger.Source.NoLettuce.listQuery(env, lastSeen_id, limit), Hamburger.Source.NoLettuce.include);
             },
         }
         export const OnlyBacon = {
             include: {"toppings":{}},
-            getQuery: (env: Env, id: number) => env.db.prepare(`WITH included as (SELECT "Hamburger"."id" AS "id", "Hamburger"."name" AS "name", "HamburgerTopping_2"."right" AS "toppings.id", "Topping_1"."name" AS "toppings.name" FROM "Hamburger" LEFT JOIN "HamburgerTopping" AS "HamburgerTopping_2" ON "Hamburger"."id" = "HamburgerTopping_2"."left" LEFT JOIN "Topping" AS "Topping_1" ON "HamburgerTopping_2"."right" = "Topping_1"."id") SELECT * FROM included WHERE [toppings.name] = 'BACON' AND id = ?1 ORDER BY id`).bind(id),
-            async get(env: Env, id: number): Promise<CloesceResult<Hamburger.Self | null>> {
+            getQuery: (env: { db: Env["db"] }, id: number) => env.db.prepare(`WITH included as (SELECT "Hamburger"."id" AS "id", "Hamburger"."name" AS "name", "HamburgerTopping_2"."right" AS "toppings.id", "Topping_1"."name" AS "toppings.name" FROM "Hamburger" LEFT JOIN "HamburgerTopping" AS "HamburgerTopping_2" ON "Hamburger"."id" = "HamburgerTopping_2"."left" LEFT JOIN "Topping" AS "Topping_1" ON "HamburgerTopping_2"."right" = "Topping_1"."id") SELECT * FROM included WHERE [toppings.name] = 'BACON' AND id = ?1 ORDER BY id`).bind(id),
+            async get(env: { db: Env["db"] }, id: number): Promise<CloesceResult<Hamburger.Self | null>> {
                 return await CloesceOrm.fromEnv(env).get<Hamburger.Self>(Hamburger.Meta, Hamburger.Source.OnlyBacon.getQuery(env, id), Hamburger.Source.OnlyBacon.include, {  });
             },
-            listQuery: (env: Env, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "Hamburger"."id" AS "id", "Hamburger"."name" AS "name", "HamburgerTopping_2"."right" AS "toppings.id", "Topping_1"."name" AS "toppings.name" FROM "Hamburger" LEFT JOIN "HamburgerTopping" AS "HamburgerTopping_2" ON "Hamburger"."id" = "HamburgerTopping_2"."left" LEFT JOIN "Topping" AS "Topping_1" ON "HamburgerTopping_2"."right" = "Topping_1"."id" WHERE "Hamburger"."id" > ?1 ORDER BY "Hamburger"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
-            async list(env: Env, lastSeen_id: number, limit: number): Promise<CloesceResult<Hamburger.Self[]>> {
+            listQuery: (env: { db: Env["db"] }, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "Hamburger"."id" AS "id", "Hamburger"."name" AS "name", "HamburgerTopping_2"."right" AS "toppings.id", "Topping_1"."name" AS "toppings.name" FROM "Hamburger" LEFT JOIN "HamburgerTopping" AS "HamburgerTopping_2" ON "Hamburger"."id" = "HamburgerTopping_2"."left" LEFT JOIN "Topping" AS "Topping_1" ON "HamburgerTopping_2"."right" = "Topping_1"."id" WHERE "Hamburger"."id" > ?1 ORDER BY "Hamburger"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
+            async list(env: { db: Env["db"] }, lastSeen_id: number, limit: number): Promise<CloesceResult<Hamburger.Self[]>> {
                 return await CloesceOrm.fromEnv(env).list<Hamburger.Self>(Hamburger.Meta, Hamburger.Source.OnlyBacon.listQuery(env, lastSeen_id, limit), Hamburger.Source.OnlyBacon.include);
             },
         }
     }
 
     export namespace Orm {
-        export async function save(env: Env, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
+        export async function save(env: { db: Env["db"] }, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
             return await CloesceOrm.fromEnv(env).upsert<Self>(Meta, newModel, include);
         }
 
-        export async function get(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Self | null>> {
+        export async function get(env: { db: Env["db"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Self | null>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).get<Self>(Meta, args.query, args.include, {});
         }
 
-        export async function list(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Hamburger.Self[]>> {
+        export async function list(env: { db: Env["db"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Hamburger.Self[]>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).list<Self>(Meta, args.query, args.include);
         }
@@ -109,7 +107,7 @@ export namespace Hamburger {
             return CloesceOrm.map<Self>(Meta, result, Source.Default.include);
         }
 
-        export async function hydrate(env: Env, base: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
+        export async function hydrate(env: { db: Env["db"] }, base: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
             return await CloesceOrm.fromEnv(env).hydrate<Self>(Meta, base, {  }, include);
         }
     }
@@ -139,28 +137,28 @@ export namespace Topping {
     export namespace Source {
         export const Default = {
             include: {"hamburger":{}},
-            getQuery: (env: Env, id: number) => env.db.prepare(`SELECT "Topping"."id" AS "id", "Topping"."name" AS "name", "HamburgerTopping_2"."left" AS "hamburger.id", "Hamburger_1"."name" AS "hamburger.name" FROM "Topping" LEFT JOIN "HamburgerTopping" AS "HamburgerTopping_2" ON "Topping"."id" = "HamburgerTopping_2"."right" LEFT JOIN "Hamburger" AS "Hamburger_1" ON "HamburgerTopping_2"."left" = "Hamburger_1"."id" WHERE "Topping"."id" = ?1`).bind(id),
-            async get(env: Env, id: number): Promise<CloesceResult<Topping.Self | null>> {
+            getQuery: (env: { db: Env["db"] }, id: number) => env.db.prepare(`SELECT "Topping"."id" AS "id", "Topping"."name" AS "name", "HamburgerTopping_2"."left" AS "hamburger.id", "Hamburger_1"."name" AS "hamburger.name" FROM "Topping" LEFT JOIN "HamburgerTopping" AS "HamburgerTopping_2" ON "Topping"."id" = "HamburgerTopping_2"."right" LEFT JOIN "Hamburger" AS "Hamburger_1" ON "HamburgerTopping_2"."left" = "Hamburger_1"."id" WHERE "Topping"."id" = ?1`).bind(id),
+            async get(env: { db: Env["db"] }, id: number): Promise<CloesceResult<Topping.Self | null>> {
                 return await CloesceOrm.fromEnv(env).get<Topping.Self>(Topping.Meta, Topping.Source.Default.getQuery(env, id), Topping.Source.Default.include, {  });
             },
-            listQuery: (env: Env, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "Topping"."id" AS "id", "Topping"."name" AS "name", "HamburgerTopping_2"."left" AS "hamburger.id", "Hamburger_1"."name" AS "hamburger.name" FROM "Topping" LEFT JOIN "HamburgerTopping" AS "HamburgerTopping_2" ON "Topping"."id" = "HamburgerTopping_2"."right" LEFT JOIN "Hamburger" AS "Hamburger_1" ON "HamburgerTopping_2"."left" = "Hamburger_1"."id" WHERE "Topping"."id" > ?1 ORDER BY "Topping"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
-            async list(env: Env, lastSeen_id: number, limit: number): Promise<CloesceResult<Topping.Self[]>> {
+            listQuery: (env: { db: Env["db"] }, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "Topping"."id" AS "id", "Topping"."name" AS "name", "HamburgerTopping_2"."left" AS "hamburger.id", "Hamburger_1"."name" AS "hamburger.name" FROM "Topping" LEFT JOIN "HamburgerTopping" AS "HamburgerTopping_2" ON "Topping"."id" = "HamburgerTopping_2"."right" LEFT JOIN "Hamburger" AS "Hamburger_1" ON "HamburgerTopping_2"."left" = "Hamburger_1"."id" WHERE "Topping"."id" > ?1 ORDER BY "Topping"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
+            async list(env: { db: Env["db"] }, lastSeen_id: number, limit: number): Promise<CloesceResult<Topping.Self[]>> {
                 return await CloesceOrm.fromEnv(env).list<Topping.Self>(Topping.Meta, Topping.Source.Default.listQuery(env, lastSeen_id, limit), Topping.Source.Default.include);
             },
         }
     }
 
     export namespace Orm {
-        export async function save(env: Env, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
+        export async function save(env: { db: Env["db"] }, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
             return await CloesceOrm.fromEnv(env).upsert<Self>(Meta, newModel, include);
         }
 
-        export async function get(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Self | null>> {
+        export async function get(env: { db: Env["db"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Self | null>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).get<Self>(Meta, args.query, args.include, {});
         }
 
-        export async function list(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Topping.Self[]>> {
+        export async function list(env: { db: Env["db"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Topping.Self[]>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).list<Self>(Meta, args.query, args.include);
         }
@@ -173,7 +171,7 @@ export namespace Topping {
             return CloesceOrm.map<Self>(Meta, result, Source.Default.include);
         }
 
-        export async function hydrate(env: Env, base: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
+        export async function hydrate(env: { db: Env["db"] }, base: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
             return await CloesceOrm.fromEnv(env).hydrate<Self>(Meta, base, {  }, include);
         }
     }

--- a/tests/e2e/fixtures/blobs/backend.ts
+++ b/tests/e2e/fixtures/blobs/backend.ts
@@ -14,7 +14,6 @@ export namespace BlobService {
     export const Tag = "BlobService" as const;
 
     export interface Api {
-
         incrementBlob(
             b: Uint8Array,
         ): ApiResult<Uint8Array>;
@@ -40,15 +39,12 @@ export namespace BlobHaver {
     }
 
     export interface Api {
-
         getBlob1(
             self: BlobHaver.Self,
         ): ApiResult<Uint8Array>;
-
         inputStream(
             s: CfReadableStream,
         ): ApiResult<void>;
-
         yieldStream(
             self: BlobHaver.Self,
         ): ApiResult<CfReadableStream>;
@@ -62,28 +58,28 @@ export namespace BlobHaver {
     export namespace Source {
         export const Default = {
             include: {},
-            getQuery: (env: Env, id: number) => env.db.prepare(`SELECT "BlobHaver"."id" AS "id", "BlobHaver"."blob1" AS "blob1", "BlobHaver"."blob2" AS "blob2" FROM "BlobHaver" WHERE "BlobHaver"."id" = ?1`).bind(id),
-            async get(env: Env, id: number): Promise<CloesceResult<BlobHaver.Self | null>> {
+            getQuery: (env: { db: Env["db"] }, id: number) => env.db.prepare(`SELECT "BlobHaver"."id" AS "id", "BlobHaver"."blob1" AS "blob1", "BlobHaver"."blob2" AS "blob2" FROM "BlobHaver" WHERE "BlobHaver"."id" = ?1`).bind(id),
+            async get(env: { db: Env["db"] }, id: number): Promise<CloesceResult<BlobHaver.Self | null>> {
                 return await CloesceOrm.fromEnv(env).get<BlobHaver.Self>(BlobHaver.Meta, BlobHaver.Source.Default.getQuery(env, id), BlobHaver.Source.Default.include, {  });
             },
-            listQuery: (env: Env, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "BlobHaver"."id" AS "id", "BlobHaver"."blob1" AS "blob1", "BlobHaver"."blob2" AS "blob2" FROM "BlobHaver" WHERE "BlobHaver"."id" > ?1 ORDER BY "BlobHaver"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
-            async list(env: Env, lastSeen_id: number, limit: number): Promise<CloesceResult<BlobHaver.Self[]>> {
+            listQuery: (env: { db: Env["db"] }, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "BlobHaver"."id" AS "id", "BlobHaver"."blob1" AS "blob1", "BlobHaver"."blob2" AS "blob2" FROM "BlobHaver" WHERE "BlobHaver"."id" > ?1 ORDER BY "BlobHaver"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
+            async list(env: { db: Env["db"] }, lastSeen_id: number, limit: number): Promise<CloesceResult<BlobHaver.Self[]>> {
                 return await CloesceOrm.fromEnv(env).list<BlobHaver.Self>(BlobHaver.Meta, BlobHaver.Source.Default.listQuery(env, lastSeen_id, limit), BlobHaver.Source.Default.include);
             },
         }
     }
 
     export namespace Orm {
-        export async function save(env: Env, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
+        export async function save(env: { db: Env["db"] }, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
             return await CloesceOrm.fromEnv(env).upsert<Self>(Meta, newModel, include);
         }
 
-        export async function get(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Self | null>> {
+        export async function get(env: { db: Env["db"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Self | null>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).get<Self>(Meta, args.query, args.include, {});
         }
 
-        export async function list(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<BlobHaver.Self[]>> {
+        export async function list(env: { db: Env["db"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<BlobHaver.Self[]>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).list<Self>(Meta, args.query, args.include);
         }
@@ -96,7 +92,7 @@ export namespace BlobHaver {
             return CloesceOrm.map<Self>(Meta, result, Source.Default.include);
         }
 
-        export async function hydrate(env: Env, base: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
+        export async function hydrate(env: { db: Env["db"] }, base: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
             return await CloesceOrm.fromEnv(env).hydrate<Self>(Meta, base, {  }, include);
         }
     }

--- a/tests/e2e/fixtures/bools_dates_ints/backend.ts
+++ b/tests/e2e/fixtures/bools_dates_ints/backend.ts
@@ -34,28 +34,28 @@ export namespace Weather {
     export namespace Source {
         export const Default = {
             include: {},
-            getQuery: (env: Env, id: number) => env.db.prepare(`SELECT "Weather"."id" AS "id", "Weather"."date" AS "date", "Weather"."isRaining" AS "isRaining" FROM "Weather" WHERE "Weather"."id" = ?1`).bind(id),
-            async get(env: Env, id: number): Promise<CloesceResult<Weather.Self | null>> {
+            getQuery: (env: { db: Env["db"] }, id: number) => env.db.prepare(`SELECT "Weather"."id" AS "id", "Weather"."date" AS "date", "Weather"."isRaining" AS "isRaining" FROM "Weather" WHERE "Weather"."id" = ?1`).bind(id),
+            async get(env: { db: Env["db"] }, id: number): Promise<CloesceResult<Weather.Self | null>> {
                 return await CloesceOrm.fromEnv(env).get<Weather.Self>(Weather.Meta, Weather.Source.Default.getQuery(env, id), Weather.Source.Default.include, {  });
             },
-            listQuery: (env: Env, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "Weather"."id" AS "id", "Weather"."date" AS "date", "Weather"."isRaining" AS "isRaining" FROM "Weather" WHERE "Weather"."id" > ?1 ORDER BY "Weather"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
-            async list(env: Env, lastSeen_id: number, limit: number): Promise<CloesceResult<Weather.Self[]>> {
+            listQuery: (env: { db: Env["db"] }, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "Weather"."id" AS "id", "Weather"."date" AS "date", "Weather"."isRaining" AS "isRaining" FROM "Weather" WHERE "Weather"."id" > ?1 ORDER BY "Weather"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
+            async list(env: { db: Env["db"] }, lastSeen_id: number, limit: number): Promise<CloesceResult<Weather.Self[]>> {
                 return await CloesceOrm.fromEnv(env).list<Weather.Self>(Weather.Meta, Weather.Source.Default.listQuery(env, lastSeen_id, limit), Weather.Source.Default.include);
             },
         }
     }
 
     export namespace Orm {
-        export async function save(env: Env, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
+        export async function save(env: { db: Env["db"] }, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
             return await CloesceOrm.fromEnv(env).upsert<Self>(Meta, newModel, include);
         }
 
-        export async function get(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Self | null>> {
+        export async function get(env: { db: Env["db"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Self | null>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).get<Self>(Meta, args.query, args.include, {});
         }
 
-        export async function list(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Weather.Self[]>> {
+        export async function list(env: { db: Env["db"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Weather.Self[]>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).list<Self>(Meta, args.query, args.include);
         }
@@ -68,7 +68,7 @@ export namespace Weather {
             return CloesceOrm.map<Self>(Meta, result, Source.Default.include);
         }
 
-        export async function hydrate(env: Env, base: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
+        export async function hydrate(env: { db: Env["db"] }, base: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
             return await CloesceOrm.fromEnv(env).hydrate<Self>(Meta, base, {  }, include);
         }
     }

--- a/tests/e2e/fixtures/composite_keys/backend.ts
+++ b/tests/e2e/fixtures/composite_keys/backend.ts
@@ -34,28 +34,28 @@ export namespace Course {
     export namespace Source {
         export const Default = {
             include: {"studentCourses":{}},
-            getQuery: (env: Env, id: number) => env.db.prepare(`SELECT "Course"."id" AS "id", "Course"."title" AS "title", "StudentCourse_1"."studentId" AS "studentCourses.studentId", "StudentCourse_1"."studentName" AS "studentCourses.studentName", "StudentCourse_1"."courseId" AS "studentCourses.courseId" FROM "Course" LEFT JOIN "StudentCourse" AS "StudentCourse_1" ON "Course"."id" = "StudentCourse_1"."courseId" WHERE "Course"."id" = ?1`).bind(id),
-            async get(env: Env, id: number): Promise<CloesceResult<Course.Self | null>> {
+            getQuery: (env: { db: Env["db"] }, id: number) => env.db.prepare(`SELECT "Course"."id" AS "id", "Course"."title" AS "title", "StudentCourse_1"."studentId" AS "studentCourses.studentId", "StudentCourse_1"."studentName" AS "studentCourses.studentName", "StudentCourse_1"."courseId" AS "studentCourses.courseId" FROM "Course" LEFT JOIN "StudentCourse" AS "StudentCourse_1" ON "Course"."id" = "StudentCourse_1"."courseId" WHERE "Course"."id" = ?1`).bind(id),
+            async get(env: { db: Env["db"] }, id: number): Promise<CloesceResult<Course.Self | null>> {
                 return await CloesceOrm.fromEnv(env).get<Course.Self>(Course.Meta, Course.Source.Default.getQuery(env, id), Course.Source.Default.include, {  });
             },
-            listQuery: (env: Env, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "Course"."id" AS "id", "Course"."title" AS "title", "StudentCourse_1"."studentId" AS "studentCourses.studentId", "StudentCourse_1"."studentName" AS "studentCourses.studentName", "StudentCourse_1"."courseId" AS "studentCourses.courseId" FROM "Course" LEFT JOIN "StudentCourse" AS "StudentCourse_1" ON "Course"."id" = "StudentCourse_1"."courseId" WHERE "Course"."id" > ?1 ORDER BY "Course"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
-            async list(env: Env, lastSeen_id: number, limit: number): Promise<CloesceResult<Course.Self[]>> {
+            listQuery: (env: { db: Env["db"] }, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "Course"."id" AS "id", "Course"."title" AS "title", "StudentCourse_1"."studentId" AS "studentCourses.studentId", "StudentCourse_1"."studentName" AS "studentCourses.studentName", "StudentCourse_1"."courseId" AS "studentCourses.courseId" FROM "Course" LEFT JOIN "StudentCourse" AS "StudentCourse_1" ON "Course"."id" = "StudentCourse_1"."courseId" WHERE "Course"."id" > ?1 ORDER BY "Course"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
+            async list(env: { db: Env["db"] }, lastSeen_id: number, limit: number): Promise<CloesceResult<Course.Self[]>> {
                 return await CloesceOrm.fromEnv(env).list<Course.Self>(Course.Meta, Course.Source.Default.listQuery(env, lastSeen_id, limit), Course.Source.Default.include);
             },
         }
     }
 
     export namespace Orm {
-        export async function save(env: Env, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
+        export async function save(env: { db: Env["db"] }, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
             return await CloesceOrm.fromEnv(env).upsert<Self>(Meta, newModel, include);
         }
 
-        export async function get(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Self | null>> {
+        export async function get(env: { db: Env["db"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Self | null>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).get<Self>(Meta, args.query, args.include, {});
         }
 
-        export async function list(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Course.Self[]>> {
+        export async function list(env: { db: Env["db"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Course.Self[]>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).list<Self>(Meta, args.query, args.include);
         }
@@ -68,7 +68,7 @@ export namespace Course {
             return CloesceOrm.map<Self>(Meta, result, Source.Default.include);
         }
 
-        export async function hydrate(env: Env, base: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
+        export async function hydrate(env: { db: Env["db"] }, base: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
             return await CloesceOrm.fromEnv(env).hydrate<Self>(Meta, base, {  }, include);
         }
     }
@@ -99,39 +99,39 @@ export namespace Student {
     export namespace Source {
         export const CoursesOrderedDescending = {
             include: {"studentCourses":{}},
-            getQuery: (env: Env, id: number, name: string) => env.db.prepare(`SELECT "Student"."id" AS "id", "Student"."name" AS "name", "Student"."favoriteColor" AS "favoriteColor", "StudentCourse_1"."studentId" AS "studentCourses.studentId", "StudentCourse_1"."studentName" AS "studentCourses.studentName", "StudentCourse_1"."courseId" AS "studentCourses.courseId" FROM "Student" LEFT JOIN "StudentCourse" AS "StudentCourse_1" ON "Student"."id" = "StudentCourse_1"."studentId" AND "Student"."name" = "StudentCourse_1"."studentName" WHERE ("Student"."id", "Student"."name") = (?1, ?2)`).bind(id, name),
-            async get(env: Env, id: number, name: string): Promise<CloesceResult<Student.Self | null>> {
+            getQuery: (env: { db: Env["db"] }, id: number, name: string) => env.db.prepare(`SELECT "Student"."id" AS "id", "Student"."name" AS "name", "Student"."favoriteColor" AS "favoriteColor", "StudentCourse_1"."studentId" AS "studentCourses.studentId", "StudentCourse_1"."studentName" AS "studentCourses.studentName", "StudentCourse_1"."courseId" AS "studentCourses.courseId" FROM "Student" LEFT JOIN "StudentCourse" AS "StudentCourse_1" ON "Student"."id" = "StudentCourse_1"."studentId" AND "Student"."name" = "StudentCourse_1"."studentName" WHERE ("Student"."id", "Student"."name") = (?1, ?2)`).bind(id, name),
+            async get(env: { db: Env["db"] }, id: number, name: string): Promise<CloesceResult<Student.Self | null>> {
                 return await CloesceOrm.fromEnv(env).get<Student.Self>(Student.Meta, Student.Source.CoursesOrderedDescending.getQuery(env, id, name), Student.Source.CoursesOrderedDescending.include, {  });
             },
-            listQuery: (env: Env, lastId: number, lastName: string, limit: number) => env.db.prepare(`WITH students AS (SELECT "Student"."id" AS "id", "Student"."name" AS "name", "Student"."favoriteColor" AS "favoriteColor", "StudentCourse_1"."studentId" AS "studentCourses.studentId", "StudentCourse_1"."studentName" AS "studentCourses.studentName", "StudentCourse_1"."courseId" AS "studentCourses.courseId" FROM "Student" LEFT JOIN "StudentCourse" AS "StudentCourse_1" ON "Student"."id" = "StudentCourse_1"."studentId" AND "Student"."name" = "StudentCourse_1"."studentName") SELECT * FROM students WHERE id > ?1 AND name > ?2 ORDER BY id DESC, name DESC LIMIT ?3`).bind(lastId, lastName, limit),
-            async list(env: Env, lastId: number, lastName: string, limit: number): Promise<CloesceResult<Student.Self[]>> {
+            listQuery: (env: { db: Env["db"] }, lastId: number, lastName: string, limit: number) => env.db.prepare(`WITH students AS (SELECT "Student"."id" AS "id", "Student"."name" AS "name", "Student"."favoriteColor" AS "favoriteColor", "StudentCourse_1"."studentId" AS "studentCourses.studentId", "StudentCourse_1"."studentName" AS "studentCourses.studentName", "StudentCourse_1"."courseId" AS "studentCourses.courseId" FROM "Student" LEFT JOIN "StudentCourse" AS "StudentCourse_1" ON "Student"."id" = "StudentCourse_1"."studentId" AND "Student"."name" = "StudentCourse_1"."studentName") SELECT * FROM students WHERE id > ?1 AND name > ?2 ORDER BY id DESC, name DESC LIMIT ?3`).bind(lastId, lastName, limit),
+            async list(env: { db: Env["db"] }, lastId: number, lastName: string, limit: number): Promise<CloesceResult<Student.Self[]>> {
                 return await CloesceOrm.fromEnv(env).list<Student.Self>(Student.Meta, Student.Source.CoursesOrderedDescending.listQuery(env, lastId, lastName, limit), Student.Source.CoursesOrderedDescending.include);
             },
         }
         export const Default = {
             include: {"studentCourses":{}},
-            getQuery: (env: Env, id: number, name: string) => env.db.prepare(`SELECT "Student"."id" AS "id", "Student"."name" AS "name", "Student"."favoriteColor" AS "favoriteColor", "StudentCourse_1"."studentId" AS "studentCourses.studentId", "StudentCourse_1"."studentName" AS "studentCourses.studentName", "StudentCourse_1"."courseId" AS "studentCourses.courseId" FROM "Student" LEFT JOIN "StudentCourse" AS "StudentCourse_1" ON "Student"."id" = "StudentCourse_1"."studentId" AND "Student"."name" = "StudentCourse_1"."studentName" WHERE ("Student"."id", "Student"."name") = (?1, ?2)`).bind(id, name),
-            async get(env: Env, id: number, name: string): Promise<CloesceResult<Student.Self | null>> {
+            getQuery: (env: { db: Env["db"] }, id: number, name: string) => env.db.prepare(`SELECT "Student"."id" AS "id", "Student"."name" AS "name", "Student"."favoriteColor" AS "favoriteColor", "StudentCourse_1"."studentId" AS "studentCourses.studentId", "StudentCourse_1"."studentName" AS "studentCourses.studentName", "StudentCourse_1"."courseId" AS "studentCourses.courseId" FROM "Student" LEFT JOIN "StudentCourse" AS "StudentCourse_1" ON "Student"."id" = "StudentCourse_1"."studentId" AND "Student"."name" = "StudentCourse_1"."studentName" WHERE ("Student"."id", "Student"."name") = (?1, ?2)`).bind(id, name),
+            async get(env: { db: Env["db"] }, id: number, name: string): Promise<CloesceResult<Student.Self | null>> {
                 return await CloesceOrm.fromEnv(env).get<Student.Self>(Student.Meta, Student.Source.Default.getQuery(env, id, name), Student.Source.Default.include, {  });
             },
-            listQuery: (env: Env, lastSeen_id: number, lastSeen_name: string, limit: number) => env.db.prepare(`SELECT "Student"."id" AS "id", "Student"."name" AS "name", "Student"."favoriteColor" AS "favoriteColor", "StudentCourse_1"."studentId" AS "studentCourses.studentId", "StudentCourse_1"."studentName" AS "studentCourses.studentName", "StudentCourse_1"."courseId" AS "studentCourses.courseId" FROM "Student" LEFT JOIN "StudentCourse" AS "StudentCourse_1" ON "Student"."id" = "StudentCourse_1"."studentId" AND "Student"."name" = "StudentCourse_1"."studentName" WHERE ("Student"."id", "Student"."name") > (?1, ?2) ORDER BY "Student"."id" ASC, "Student"."name" ASC LIMIT ?3`).bind(lastSeen_id, lastSeen_name, limit),
-            async list(env: Env, lastSeen_id: number, lastSeen_name: string, limit: number): Promise<CloesceResult<Student.Self[]>> {
+            listQuery: (env: { db: Env["db"] }, lastSeen_id: number, lastSeen_name: string, limit: number) => env.db.prepare(`SELECT "Student"."id" AS "id", "Student"."name" AS "name", "Student"."favoriteColor" AS "favoriteColor", "StudentCourse_1"."studentId" AS "studentCourses.studentId", "StudentCourse_1"."studentName" AS "studentCourses.studentName", "StudentCourse_1"."courseId" AS "studentCourses.courseId" FROM "Student" LEFT JOIN "StudentCourse" AS "StudentCourse_1" ON "Student"."id" = "StudentCourse_1"."studentId" AND "Student"."name" = "StudentCourse_1"."studentName" WHERE ("Student"."id", "Student"."name") > (?1, ?2) ORDER BY "Student"."id" ASC, "Student"."name" ASC LIMIT ?3`).bind(lastSeen_id, lastSeen_name, limit),
+            async list(env: { db: Env["db"] }, lastSeen_id: number, lastSeen_name: string, limit: number): Promise<CloesceResult<Student.Self[]>> {
                 return await CloesceOrm.fromEnv(env).list<Student.Self>(Student.Meta, Student.Source.Default.listQuery(env, lastSeen_id, lastSeen_name, limit), Student.Source.Default.include);
             },
         }
     }
 
     export namespace Orm {
-        export async function save(env: Env, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
+        export async function save(env: { db: Env["db"] }, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
             return await CloesceOrm.fromEnv(env).upsert<Self>(Meta, newModel, include);
         }
 
-        export async function get(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Self | null>> {
+        export async function get(env: { db: Env["db"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Self | null>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).get<Self>(Meta, args.query, args.include, {});
         }
 
-        export async function list(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Student.Self[]>> {
+        export async function list(env: { db: Env["db"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Student.Self[]>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).list<Self>(Meta, args.query, args.include);
         }
@@ -144,7 +144,7 @@ export namespace Student {
             return CloesceOrm.map<Self>(Meta, result, Source.Default.include);
         }
 
-        export async function hydrate(env: Env, base: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
+        export async function hydrate(env: { db: Env["db"] }, base: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
             return await CloesceOrm.fromEnv(env).hydrate<Self>(Meta, base, {  }, include);
         }
     }
@@ -176,39 +176,39 @@ export namespace StudentCourse {
     export namespace Source {
         export const Default = {
             include: {},
-            getQuery: (env: Env, studentId: number, studentName: string, courseId: number) => env.db.prepare(`SELECT "StudentCourse"."studentId" AS "studentId", "StudentCourse"."studentName" AS "studentName", "StudentCourse"."courseId" AS "courseId" FROM "StudentCourse" WHERE ("StudentCourse"."studentId", "StudentCourse"."studentName", "StudentCourse"."courseId") = (?1, ?2, ?3)`).bind(studentId, studentName, courseId),
-            async get(env: Env, studentId: number, studentName: string, courseId: number): Promise<CloesceResult<StudentCourse.Self | null>> {
+            getQuery: (env: { db: Env["db"] }, studentId: number, studentName: string, courseId: number) => env.db.prepare(`SELECT "StudentCourse"."studentId" AS "studentId", "StudentCourse"."studentName" AS "studentName", "StudentCourse"."courseId" AS "courseId" FROM "StudentCourse" WHERE ("StudentCourse"."studentId", "StudentCourse"."studentName", "StudentCourse"."courseId") = (?1, ?2, ?3)`).bind(studentId, studentName, courseId),
+            async get(env: { db: Env["db"] }, studentId: number, studentName: string, courseId: number): Promise<CloesceResult<StudentCourse.Self | null>> {
                 return await CloesceOrm.fromEnv(env).get<StudentCourse.Self>(StudentCourse.Meta, StudentCourse.Source.Default.getQuery(env, studentId, studentName, courseId), StudentCourse.Source.Default.include, {  });
             },
-            listQuery: (env: Env, lastSeen_studentId: number, lastSeen_studentName: string, lastSeen_courseId: number, limit: number) => env.db.prepare(`SELECT "StudentCourse"."studentId" AS "studentId", "StudentCourse"."studentName" AS "studentName", "StudentCourse"."courseId" AS "courseId" FROM "StudentCourse" WHERE ("StudentCourse"."studentId", "StudentCourse"."studentName", "StudentCourse"."courseId") > (?1, ?2, ?3) ORDER BY "StudentCourse"."studentId" ASC, "StudentCourse"."studentName" ASC, "StudentCourse"."courseId" ASC LIMIT ?4`).bind(lastSeen_studentId, lastSeen_studentName, lastSeen_courseId, limit),
-            async list(env: Env, lastSeen_studentId: number, lastSeen_studentName: string, lastSeen_courseId: number, limit: number): Promise<CloesceResult<StudentCourse.Self[]>> {
+            listQuery: (env: { db: Env["db"] }, lastSeen_studentId: number, lastSeen_studentName: string, lastSeen_courseId: number, limit: number) => env.db.prepare(`SELECT "StudentCourse"."studentId" AS "studentId", "StudentCourse"."studentName" AS "studentName", "StudentCourse"."courseId" AS "courseId" FROM "StudentCourse" WHERE ("StudentCourse"."studentId", "StudentCourse"."studentName", "StudentCourse"."courseId") > (?1, ?2, ?3) ORDER BY "StudentCourse"."studentId" ASC, "StudentCourse"."studentName" ASC, "StudentCourse"."courseId" ASC LIMIT ?4`).bind(lastSeen_studentId, lastSeen_studentName, lastSeen_courseId, limit),
+            async list(env: { db: Env["db"] }, lastSeen_studentId: number, lastSeen_studentName: string, lastSeen_courseId: number, limit: number): Promise<CloesceResult<StudentCourse.Self[]>> {
                 return await CloesceOrm.fromEnv(env).list<StudentCourse.Self>(StudentCourse.Meta, StudentCourse.Source.Default.listQuery(env, lastSeen_studentId, lastSeen_studentName, lastSeen_courseId, limit), StudentCourse.Source.Default.include);
             },
         }
         export const WithStudentCourse = {
             include: {"course":{"studentCourses":{}},"student":{"studentCourses":{}}},
-            getQuery: (env: Env, studentId: number, studentName: string, courseId: number) => env.db.prepare(`SELECT "StudentCourse"."studentId" AS "studentId", "StudentCourse"."studentName" AS "studentName", "StudentCourse"."courseId" AS "courseId", "Student_1"."id" AS "student.id", "Student_1"."name" AS "student.name", "Student_1"."favoriteColor" AS "student.favoriteColor", "StudentCourse_2"."studentId" AS "student.studentCourses.studentId", "StudentCourse_2"."studentName" AS "student.studentCourses.studentName", "StudentCourse_2"."courseId" AS "student.studentCourses.courseId", "Course_3"."id" AS "course.id", "Course_3"."title" AS "course.title", "StudentCourse_4"."studentId" AS "course.studentCourses.studentId", "StudentCourse_4"."studentName" AS "course.studentCourses.studentName", "StudentCourse_4"."courseId" AS "course.studentCourses.courseId" FROM "StudentCourse" LEFT JOIN "Student" AS "Student_1" ON "StudentCourse"."studentId" = "Student_1"."id" AND "StudentCourse"."studentName" = "Student_1"."name" LEFT JOIN "StudentCourse" AS "StudentCourse_2" ON "Student_1"."id" = "StudentCourse_2"."studentId" AND "Student_1"."name" = "StudentCourse_2"."studentName" LEFT JOIN "Course" AS "Course_3" ON "StudentCourse"."courseId" = "Course_3"."id" LEFT JOIN "StudentCourse" AS "StudentCourse_4" ON "Course_3"."id" = "StudentCourse_4"."courseId" WHERE ("StudentCourse"."studentId", "StudentCourse"."studentName", "StudentCourse"."courseId") = (?1, ?2, ?3)`).bind(studentId, studentName, courseId),
-            async get(env: Env, studentId: number, studentName: string, courseId: number): Promise<CloesceResult<StudentCourse.Self | null>> {
+            getQuery: (env: { db: Env["db"] }, studentId: number, studentName: string, courseId: number) => env.db.prepare(`SELECT "StudentCourse"."studentId" AS "studentId", "StudentCourse"."studentName" AS "studentName", "StudentCourse"."courseId" AS "courseId", "Student_1"."id" AS "student.id", "Student_1"."name" AS "student.name", "Student_1"."favoriteColor" AS "student.favoriteColor", "StudentCourse_2"."studentId" AS "student.studentCourses.studentId", "StudentCourse_2"."studentName" AS "student.studentCourses.studentName", "StudentCourse_2"."courseId" AS "student.studentCourses.courseId", "Course_3"."id" AS "course.id", "Course_3"."title" AS "course.title", "StudentCourse_4"."studentId" AS "course.studentCourses.studentId", "StudentCourse_4"."studentName" AS "course.studentCourses.studentName", "StudentCourse_4"."courseId" AS "course.studentCourses.courseId" FROM "StudentCourse" LEFT JOIN "Student" AS "Student_1" ON "StudentCourse"."studentId" = "Student_1"."id" AND "StudentCourse"."studentName" = "Student_1"."name" LEFT JOIN "StudentCourse" AS "StudentCourse_2" ON "Student_1"."id" = "StudentCourse_2"."studentId" AND "Student_1"."name" = "StudentCourse_2"."studentName" LEFT JOIN "Course" AS "Course_3" ON "StudentCourse"."courseId" = "Course_3"."id" LEFT JOIN "StudentCourse" AS "StudentCourse_4" ON "Course_3"."id" = "StudentCourse_4"."courseId" WHERE ("StudentCourse"."studentId", "StudentCourse"."studentName", "StudentCourse"."courseId") = (?1, ?2, ?3)`).bind(studentId, studentName, courseId),
+            async get(env: { db: Env["db"] }, studentId: number, studentName: string, courseId: number): Promise<CloesceResult<StudentCourse.Self | null>> {
                 return await CloesceOrm.fromEnv(env).get<StudentCourse.Self>(StudentCourse.Meta, StudentCourse.Source.WithStudentCourse.getQuery(env, studentId, studentName, courseId), StudentCourse.Source.WithStudentCourse.include, {  });
             },
-            listQuery: (env: Env, lastSeen_studentId: number, lastSeen_studentName: string, lastSeen_courseId: number, limit: number) => env.db.prepare(`SELECT "StudentCourse"."studentId" AS "studentId", "StudentCourse"."studentName" AS "studentName", "StudentCourse"."courseId" AS "courseId", "Student_1"."id" AS "student.id", "Student_1"."name" AS "student.name", "Student_1"."favoriteColor" AS "student.favoriteColor", "StudentCourse_2"."studentId" AS "student.studentCourses.studentId", "StudentCourse_2"."studentName" AS "student.studentCourses.studentName", "StudentCourse_2"."courseId" AS "student.studentCourses.courseId", "Course_3"."id" AS "course.id", "Course_3"."title" AS "course.title", "StudentCourse_4"."studentId" AS "course.studentCourses.studentId", "StudentCourse_4"."studentName" AS "course.studentCourses.studentName", "StudentCourse_4"."courseId" AS "course.studentCourses.courseId" FROM "StudentCourse" LEFT JOIN "Student" AS "Student_1" ON "StudentCourse"."studentId" = "Student_1"."id" AND "StudentCourse"."studentName" = "Student_1"."name" LEFT JOIN "StudentCourse" AS "StudentCourse_2" ON "Student_1"."id" = "StudentCourse_2"."studentId" AND "Student_1"."name" = "StudentCourse_2"."studentName" LEFT JOIN "Course" AS "Course_3" ON "StudentCourse"."courseId" = "Course_3"."id" LEFT JOIN "StudentCourse" AS "StudentCourse_4" ON "Course_3"."id" = "StudentCourse_4"."courseId" WHERE ("StudentCourse"."studentId", "StudentCourse"."studentName", "StudentCourse"."courseId") > (?1, ?2, ?3) ORDER BY "StudentCourse"."studentId" ASC, "StudentCourse"."studentName" ASC, "StudentCourse"."courseId" ASC LIMIT ?4`).bind(lastSeen_studentId, lastSeen_studentName, lastSeen_courseId, limit),
-            async list(env: Env, lastSeen_studentId: number, lastSeen_studentName: string, lastSeen_courseId: number, limit: number): Promise<CloesceResult<StudentCourse.Self[]>> {
+            listQuery: (env: { db: Env["db"] }, lastSeen_studentId: number, lastSeen_studentName: string, lastSeen_courseId: number, limit: number) => env.db.prepare(`SELECT "StudentCourse"."studentId" AS "studentId", "StudentCourse"."studentName" AS "studentName", "StudentCourse"."courseId" AS "courseId", "Student_1"."id" AS "student.id", "Student_1"."name" AS "student.name", "Student_1"."favoriteColor" AS "student.favoriteColor", "StudentCourse_2"."studentId" AS "student.studentCourses.studentId", "StudentCourse_2"."studentName" AS "student.studentCourses.studentName", "StudentCourse_2"."courseId" AS "student.studentCourses.courseId", "Course_3"."id" AS "course.id", "Course_3"."title" AS "course.title", "StudentCourse_4"."studentId" AS "course.studentCourses.studentId", "StudentCourse_4"."studentName" AS "course.studentCourses.studentName", "StudentCourse_4"."courseId" AS "course.studentCourses.courseId" FROM "StudentCourse" LEFT JOIN "Student" AS "Student_1" ON "StudentCourse"."studentId" = "Student_1"."id" AND "StudentCourse"."studentName" = "Student_1"."name" LEFT JOIN "StudentCourse" AS "StudentCourse_2" ON "Student_1"."id" = "StudentCourse_2"."studentId" AND "Student_1"."name" = "StudentCourse_2"."studentName" LEFT JOIN "Course" AS "Course_3" ON "StudentCourse"."courseId" = "Course_3"."id" LEFT JOIN "StudentCourse" AS "StudentCourse_4" ON "Course_3"."id" = "StudentCourse_4"."courseId" WHERE ("StudentCourse"."studentId", "StudentCourse"."studentName", "StudentCourse"."courseId") > (?1, ?2, ?3) ORDER BY "StudentCourse"."studentId" ASC, "StudentCourse"."studentName" ASC, "StudentCourse"."courseId" ASC LIMIT ?4`).bind(lastSeen_studentId, lastSeen_studentName, lastSeen_courseId, limit),
+            async list(env: { db: Env["db"] }, lastSeen_studentId: number, lastSeen_studentName: string, lastSeen_courseId: number, limit: number): Promise<CloesceResult<StudentCourse.Self[]>> {
                 return await CloesceOrm.fromEnv(env).list<StudentCourse.Self>(StudentCourse.Meta, StudentCourse.Source.WithStudentCourse.listQuery(env, lastSeen_studentId, lastSeen_studentName, lastSeen_courseId, limit), StudentCourse.Source.WithStudentCourse.include);
             },
         }
     }
 
     export namespace Orm {
-        export async function save(env: Env, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
+        export async function save(env: { db: Env["db"] }, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
             return await CloesceOrm.fromEnv(env).upsert<Self>(Meta, newModel, include);
         }
 
-        export async function get(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Self | null>> {
+        export async function get(env: { db: Env["db"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Self | null>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).get<Self>(Meta, args.query, args.include, {});
         }
 
-        export async function list(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<StudentCourse.Self[]>> {
+        export async function list(env: { db: Env["db"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<StudentCourse.Self[]>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).list<Self>(Meta, args.query, args.include);
         }
@@ -221,7 +221,7 @@ export namespace StudentCourse {
             return CloesceOrm.map<Self>(Meta, result, Source.Default.include);
         }
 
-        export async function hydrate(env: Env, base: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
+        export async function hydrate(env: { db: Env["db"] }, base: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
             return await CloesceOrm.fromEnv(env).hydrate<Self>(Meta, base, {  }, include);
         }
     }

--- a/tests/e2e/fixtures/d1_crud/backend.ts
+++ b/tests/e2e/fixtures/d1_crud/backend.ts
@@ -23,7 +23,6 @@ export namespace CrudHaver {
     }
 
     export interface Api {
-
         notCrud(
             self: CrudHaver.Self,
         ): ApiResult<void>;
@@ -37,28 +36,28 @@ export namespace CrudHaver {
     export namespace Source {
         export const Default = {
             include: {},
-            getQuery: (env: Env, id: number) => env.db.prepare(`SELECT "CrudHaver"."id" AS "id", "CrudHaver"."name" AS "name" FROM "CrudHaver" WHERE "CrudHaver"."id" = ?1`).bind(id),
-            async get(env: Env, id: number): Promise<CloesceResult<CrudHaver.Self | null>> {
+            getQuery: (env: { db: Env["db"] }, id: number) => env.db.prepare(`SELECT "CrudHaver"."id" AS "id", "CrudHaver"."name" AS "name" FROM "CrudHaver" WHERE "CrudHaver"."id" = ?1`).bind(id),
+            async get(env: { db: Env["db"] }, id: number): Promise<CloesceResult<CrudHaver.Self | null>> {
                 return await CloesceOrm.fromEnv(env).get<CrudHaver.Self>(CrudHaver.Meta, CrudHaver.Source.Default.getQuery(env, id), CrudHaver.Source.Default.include, {  });
             },
-            listQuery: (env: Env, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "CrudHaver"."id" AS "id", "CrudHaver"."name" AS "name" FROM "CrudHaver" WHERE "CrudHaver"."id" > ?1 ORDER BY "CrudHaver"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
-            async list(env: Env, lastSeen_id: number, limit: number): Promise<CloesceResult<CrudHaver.Self[]>> {
+            listQuery: (env: { db: Env["db"] }, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "CrudHaver"."id" AS "id", "CrudHaver"."name" AS "name" FROM "CrudHaver" WHERE "CrudHaver"."id" > ?1 ORDER BY "CrudHaver"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
+            async list(env: { db: Env["db"] }, lastSeen_id: number, limit: number): Promise<CloesceResult<CrudHaver.Self[]>> {
                 return await CloesceOrm.fromEnv(env).list<CrudHaver.Self>(CrudHaver.Meta, CrudHaver.Source.Default.listQuery(env, lastSeen_id, limit), CrudHaver.Source.Default.include);
             },
         }
     }
 
     export namespace Orm {
-        export async function save(env: Env, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
+        export async function save(env: { db: Env["db"] }, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
             return await CloesceOrm.fromEnv(env).upsert<Self>(Meta, newModel, include);
         }
 
-        export async function get(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Self | null>> {
+        export async function get(env: { db: Env["db"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Self | null>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).get<Self>(Meta, args.query, args.include, {});
         }
 
-        export async function list(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<CrudHaver.Self[]>> {
+        export async function list(env: { db: Env["db"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<CrudHaver.Self[]>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).list<Self>(Meta, args.query, args.include);
         }
@@ -71,7 +70,7 @@ export namespace CrudHaver {
             return CloesceOrm.map<Self>(Meta, result, Source.Default.include);
         }
 
-        export async function hydrate(env: Env, base: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
+        export async function hydrate(env: { db: Env["db"] }, base: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
             return await CloesceOrm.fromEnv(env).hydrate<Self>(Meta, base, {  }, include);
         }
     }
@@ -102,39 +101,39 @@ export namespace Parent {
     export namespace Source {
         export const Default = {
             include: {"children":{},"favoriteChild":{}},
-            getQuery: (env: Env, id: number) => env.db.prepare(`SELECT "Parent"."id" AS "id", "Parent"."favoriteChildId" AS "favoriteChildId", "Child_1"."id" AS "favoriteChild.id", "Child_1"."parentId" AS "favoriteChild.parentId", "Child_2"."id" AS "children.id", "Child_2"."parentId" AS "children.parentId" FROM "Parent" LEFT JOIN "Child" AS "Child_1" ON "Parent"."favoriteChildId" = "Child_1"."id" LEFT JOIN "Child" AS "Child_2" ON "Parent"."id" = "Child_2"."parentId" WHERE "Parent"."id" = ?1`).bind(id),
-            async get(env: Env, id: number): Promise<CloesceResult<Parent.Self | null>> {
+            getQuery: (env: { db: Env["db"] }, id: number) => env.db.prepare(`SELECT "Parent"."id" AS "id", "Parent"."favoriteChildId" AS "favoriteChildId", "Child_1"."id" AS "favoriteChild.id", "Child_1"."parentId" AS "favoriteChild.parentId", "Child_2"."id" AS "children.id", "Child_2"."parentId" AS "children.parentId" FROM "Parent" LEFT JOIN "Child" AS "Child_1" ON "Parent"."favoriteChildId" = "Child_1"."id" LEFT JOIN "Child" AS "Child_2" ON "Parent"."id" = "Child_2"."parentId" WHERE "Parent"."id" = ?1`).bind(id),
+            async get(env: { db: Env["db"] }, id: number): Promise<CloesceResult<Parent.Self | null>> {
                 return await CloesceOrm.fromEnv(env).get<Parent.Self>(Parent.Meta, Parent.Source.Default.getQuery(env, id), Parent.Source.Default.include, {  });
             },
-            listQuery: (env: Env, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "Parent"."id" AS "id", "Parent"."favoriteChildId" AS "favoriteChildId", "Child_1"."id" AS "favoriteChild.id", "Child_1"."parentId" AS "favoriteChild.parentId", "Child_2"."id" AS "children.id", "Child_2"."parentId" AS "children.parentId" FROM "Parent" LEFT JOIN "Child" AS "Child_1" ON "Parent"."favoriteChildId" = "Child_1"."id" LEFT JOIN "Child" AS "Child_2" ON "Parent"."id" = "Child_2"."parentId" WHERE "Parent"."id" > ?1 ORDER BY "Parent"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
-            async list(env: Env, lastSeen_id: number, limit: number): Promise<CloesceResult<Parent.Self[]>> {
+            listQuery: (env: { db: Env["db"] }, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "Parent"."id" AS "id", "Parent"."favoriteChildId" AS "favoriteChildId", "Child_1"."id" AS "favoriteChild.id", "Child_1"."parentId" AS "favoriteChild.parentId", "Child_2"."id" AS "children.id", "Child_2"."parentId" AS "children.parentId" FROM "Parent" LEFT JOIN "Child" AS "Child_1" ON "Parent"."favoriteChildId" = "Child_1"."id" LEFT JOIN "Child" AS "Child_2" ON "Parent"."id" = "Child_2"."parentId" WHERE "Parent"."id" > ?1 ORDER BY "Parent"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
+            async list(env: { db: Env["db"] }, lastSeen_id: number, limit: number): Promise<CloesceResult<Parent.Self[]>> {
                 return await CloesceOrm.fromEnv(env).list<Parent.Self>(Parent.Meta, Parent.Source.Default.listQuery(env, lastSeen_id, limit), Parent.Source.Default.include);
             },
         }
         export const WithChildren = {
             include: {"children":{},"favoriteChild":{}},
-            getQuery: (env: Env, id: number) => env.db.prepare(`SELECT "Parent"."id" AS "id", "Parent"."favoriteChildId" AS "favoriteChildId", "Child_1"."id" AS "favoriteChild.id", "Child_1"."parentId" AS "favoriteChild.parentId", "Child_2"."id" AS "children.id", "Child_2"."parentId" AS "children.parentId" FROM "Parent" LEFT JOIN "Child" AS "Child_1" ON "Parent"."favoriteChildId" = "Child_1"."id" LEFT JOIN "Child" AS "Child_2" ON "Parent"."id" = "Child_2"."parentId" WHERE "Parent"."id" = ?1`).bind(id),
-            async get(env: Env, id: number): Promise<CloesceResult<Parent.Self | null>> {
+            getQuery: (env: { db: Env["db"] }, id: number) => env.db.prepare(`SELECT "Parent"."id" AS "id", "Parent"."favoriteChildId" AS "favoriteChildId", "Child_1"."id" AS "favoriteChild.id", "Child_1"."parentId" AS "favoriteChild.parentId", "Child_2"."id" AS "children.id", "Child_2"."parentId" AS "children.parentId" FROM "Parent" LEFT JOIN "Child" AS "Child_1" ON "Parent"."favoriteChildId" = "Child_1"."id" LEFT JOIN "Child" AS "Child_2" ON "Parent"."id" = "Child_2"."parentId" WHERE "Parent"."id" = ?1`).bind(id),
+            async get(env: { db: Env["db"] }, id: number): Promise<CloesceResult<Parent.Self | null>> {
                 return await CloesceOrm.fromEnv(env).get<Parent.Self>(Parent.Meta, Parent.Source.WithChildren.getQuery(env, id), Parent.Source.WithChildren.include, {  });
             },
-            listQuery: (env: Env, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "Parent"."id" AS "id", "Parent"."favoriteChildId" AS "favoriteChildId", "Child_1"."id" AS "favoriteChild.id", "Child_1"."parentId" AS "favoriteChild.parentId", "Child_2"."id" AS "children.id", "Child_2"."parentId" AS "children.parentId" FROM "Parent" LEFT JOIN "Child" AS "Child_1" ON "Parent"."favoriteChildId" = "Child_1"."id" LEFT JOIN "Child" AS "Child_2" ON "Parent"."id" = "Child_2"."parentId" WHERE "Parent"."id" > ?1 ORDER BY "Parent"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
-            async list(env: Env, lastSeen_id: number, limit: number): Promise<CloesceResult<Parent.Self[]>> {
+            listQuery: (env: { db: Env["db"] }, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "Parent"."id" AS "id", "Parent"."favoriteChildId" AS "favoriteChildId", "Child_1"."id" AS "favoriteChild.id", "Child_1"."parentId" AS "favoriteChild.parentId", "Child_2"."id" AS "children.id", "Child_2"."parentId" AS "children.parentId" FROM "Parent" LEFT JOIN "Child" AS "Child_1" ON "Parent"."favoriteChildId" = "Child_1"."id" LEFT JOIN "Child" AS "Child_2" ON "Parent"."id" = "Child_2"."parentId" WHERE "Parent"."id" > ?1 ORDER BY "Parent"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
+            async list(env: { db: Env["db"] }, lastSeen_id: number, limit: number): Promise<CloesceResult<Parent.Self[]>> {
                 return await CloesceOrm.fromEnv(env).list<Parent.Self>(Parent.Meta, Parent.Source.WithChildren.listQuery(env, lastSeen_id, limit), Parent.Source.WithChildren.include);
             },
         }
     }
 
     export namespace Orm {
-        export async function save(env: Env, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
+        export async function save(env: { db: Env["db"] }, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
             return await CloesceOrm.fromEnv(env).upsert<Self>(Meta, newModel, include);
         }
 
-        export async function get(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Self | null>> {
+        export async function get(env: { db: Env["db"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Self | null>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).get<Self>(Meta, args.query, args.include, {});
         }
 
-        export async function list(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Parent.Self[]>> {
+        export async function list(env: { db: Env["db"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Parent.Self[]>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).list<Self>(Meta, args.query, args.include);
         }
@@ -147,7 +146,7 @@ export namespace Parent {
             return CloesceOrm.map<Self>(Meta, result, Source.Default.include);
         }
 
-        export async function hydrate(env: Env, base: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
+        export async function hydrate(env: { db: Env["db"] }, base: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
             return await CloesceOrm.fromEnv(env).hydrate<Self>(Meta, base, {  }, include);
         }
     }
@@ -177,28 +176,28 @@ export namespace Child {
     export namespace Source {
         export const Default = {
             include: {"parent":{"children":{}}},
-            getQuery: (env: Env, id: number) => env.db.prepare(`SELECT "Child"."id" AS "id", "Child"."parentId" AS "parentId", "Parent_1"."id" AS "parent.id", "Parent_1"."favoriteChildId" AS "parent.favoriteChildId", "Child_2"."id" AS "parent.children.id", "Child_2"."parentId" AS "parent.children.parentId" FROM "Child" LEFT JOIN "Parent" AS "Parent_1" ON "Child"."parentId" = "Parent_1"."id" LEFT JOIN "Child" AS "Child_2" ON "Parent_1"."id" = "Child_2"."parentId" WHERE "Child"."id" = ?1`).bind(id),
-            async get(env: Env, id: number): Promise<CloesceResult<Child.Self | null>> {
+            getQuery: (env: { db: Env["db"] }, id: number) => env.db.prepare(`SELECT "Child"."id" AS "id", "Child"."parentId" AS "parentId", "Parent_1"."id" AS "parent.id", "Parent_1"."favoriteChildId" AS "parent.favoriteChildId", "Child_2"."id" AS "parent.children.id", "Child_2"."parentId" AS "parent.children.parentId" FROM "Child" LEFT JOIN "Parent" AS "Parent_1" ON "Child"."parentId" = "Parent_1"."id" LEFT JOIN "Child" AS "Child_2" ON "Parent_1"."id" = "Child_2"."parentId" WHERE "Child"."id" = ?1`).bind(id),
+            async get(env: { db: Env["db"] }, id: number): Promise<CloesceResult<Child.Self | null>> {
                 return await CloesceOrm.fromEnv(env).get<Child.Self>(Child.Meta, Child.Source.Default.getQuery(env, id), Child.Source.Default.include, {  });
             },
-            listQuery: (env: Env, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "Child"."id" AS "id", "Child"."parentId" AS "parentId", "Parent_1"."id" AS "parent.id", "Parent_1"."favoriteChildId" AS "parent.favoriteChildId", "Child_2"."id" AS "parent.children.id", "Child_2"."parentId" AS "parent.children.parentId" FROM "Child" LEFT JOIN "Parent" AS "Parent_1" ON "Child"."parentId" = "Parent_1"."id" LEFT JOIN "Child" AS "Child_2" ON "Parent_1"."id" = "Child_2"."parentId" WHERE "Child"."id" > ?1 ORDER BY "Child"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
-            async list(env: Env, lastSeen_id: number, limit: number): Promise<CloesceResult<Child.Self[]>> {
+            listQuery: (env: { db: Env["db"] }, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "Child"."id" AS "id", "Child"."parentId" AS "parentId", "Parent_1"."id" AS "parent.id", "Parent_1"."favoriteChildId" AS "parent.favoriteChildId", "Child_2"."id" AS "parent.children.id", "Child_2"."parentId" AS "parent.children.parentId" FROM "Child" LEFT JOIN "Parent" AS "Parent_1" ON "Child"."parentId" = "Parent_1"."id" LEFT JOIN "Child" AS "Child_2" ON "Parent_1"."id" = "Child_2"."parentId" WHERE "Child"."id" > ?1 ORDER BY "Child"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
+            async list(env: { db: Env["db"] }, lastSeen_id: number, limit: number): Promise<CloesceResult<Child.Self[]>> {
                 return await CloesceOrm.fromEnv(env).list<Child.Self>(Child.Meta, Child.Source.Default.listQuery(env, lastSeen_id, limit), Child.Source.Default.include);
             },
         }
     }
 
     export namespace Orm {
-        export async function save(env: Env, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
+        export async function save(env: { db: Env["db"] }, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
             return await CloesceOrm.fromEnv(env).upsert<Self>(Meta, newModel, include);
         }
 
-        export async function get(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Self | null>> {
+        export async function get(env: { db: Env["db"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Self | null>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).get<Self>(Meta, args.query, args.include, {});
         }
 
-        export async function list(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Child.Self[]>> {
+        export async function list(env: { db: Env["db"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Child.Self[]>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).list<Self>(Meta, args.query, args.include);
         }
@@ -211,7 +210,7 @@ export namespace Child {
             return CloesceOrm.map<Self>(Meta, result, Source.Default.include);
         }
 
-        export async function hydrate(env: Env, base: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
+        export async function hydrate(env: { db: Env["db"] }, base: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
             return await CloesceOrm.fromEnv(env).hydrate<Self>(Meta, base, {  }, include);
         }
     }

--- a/tests/e2e/fixtures/fail/backend.ts
+++ b/tests/e2e/fixtures/fail/backend.ts
@@ -14,7 +14,6 @@ export namespace UnregisteredService {
     export const Tag = "UnregisteredService" as const;
 
     export interface Api {
-
         unregistered(
         ): ApiResult<string>;
     }
@@ -38,11 +37,9 @@ export namespace FailModel {
     }
 
     export interface Api {
-
         throwingMethod(
             self: FailModel.Self,
         ): ApiResult<void>;
-
         numericValidators(
             self: FailModel.Self,
             gtField: number,
@@ -51,7 +48,6 @@ export namespace FailModel {
             lteField: number,
             stepField: number,
         ): ApiResult<void>;
-
         stringValidators(
             self: FailModel.Self,
             lenField: string,
@@ -69,28 +65,28 @@ export namespace FailModel {
     export namespace Source {
         export const Default = {
             include: {},
-            getQuery: (env: Env, id: number) => env.db.prepare(`SELECT "FailModel"."id" AS "id", "FailModel"."name" AS "name" FROM "FailModel" WHERE "FailModel"."id" = ?1`).bind(id),
-            async get(env: Env, id: number): Promise<CloesceResult<FailModel.Self | null>> {
+            getQuery: (env: { db: Env["db"] }, id: number) => env.db.prepare(`SELECT "FailModel"."id" AS "id", "FailModel"."name" AS "name" FROM "FailModel" WHERE "FailModel"."id" = ?1`).bind(id),
+            async get(env: { db: Env["db"] }, id: number): Promise<CloesceResult<FailModel.Self | null>> {
                 return await CloesceOrm.fromEnv(env).get<FailModel.Self>(FailModel.Meta, FailModel.Source.Default.getQuery(env, id), FailModel.Source.Default.include, {  });
             },
-            listQuery: (env: Env, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "FailModel"."id" AS "id", "FailModel"."name" AS "name" FROM "FailModel" WHERE "FailModel"."id" > ?1 ORDER BY "FailModel"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
-            async list(env: Env, lastSeen_id: number, limit: number): Promise<CloesceResult<FailModel.Self[]>> {
+            listQuery: (env: { db: Env["db"] }, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "FailModel"."id" AS "id", "FailModel"."name" AS "name" FROM "FailModel" WHERE "FailModel"."id" > ?1 ORDER BY "FailModel"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
+            async list(env: { db: Env["db"] }, lastSeen_id: number, limit: number): Promise<CloesceResult<FailModel.Self[]>> {
                 return await CloesceOrm.fromEnv(env).list<FailModel.Self>(FailModel.Meta, FailModel.Source.Default.listQuery(env, lastSeen_id, limit), FailModel.Source.Default.include);
             },
         }
     }
 
     export namespace Orm {
-        export async function save(env: Env, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
+        export async function save(env: { db: Env["db"] }, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
             return await CloesceOrm.fromEnv(env).upsert<Self>(Meta, newModel, include);
         }
 
-        export async function get(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Self | null>> {
+        export async function get(env: { db: Env["db"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Self | null>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).get<Self>(Meta, args.query, args.include, {});
         }
 
-        export async function list(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<FailModel.Self[]>> {
+        export async function list(env: { db: Env["db"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<FailModel.Self[]>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).list<Self>(Meta, args.query, args.include);
         }
@@ -103,7 +99,7 @@ export namespace FailModel {
             return CloesceOrm.map<Self>(Meta, result, Source.Default.include);
         }
 
-        export async function hydrate(env: Env, base: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
+        export async function hydrate(env: { db: Env["db"] }, base: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
             return await CloesceOrm.fromEnv(env).hydrate<Self>(Meta, base, {  }, include);
         }
     }

--- a/tests/e2e/fixtures/foreign_keys/backend.ts
+++ b/tests/e2e/fixtures/foreign_keys/backend.ts
@@ -24,14 +24,12 @@ export namespace A {
     }
 
     export interface Api {
-
         create(
             env: {
                 db: Env["db"],
             },
             a: A.Self,
         ): ApiResult<A.Self>;
-
         withoutB(
             self: A.Self,
         ): ApiResult<A.Self>;
@@ -45,50 +43,50 @@ export namespace A {
     export namespace Source {
         export const Default = {
             include: {"b":{"a":{}}},
-            getQuery: (env: Env, id: number) => env.db.prepare(`SELECT "A"."id" AS "id", "A"."bId" AS "bId", "B_1"."id" AS "b.id", "A_2"."id" AS "b.a.id", "A_2"."bId" AS "b.a.bId" FROM "A" LEFT JOIN "B" AS "B_1" ON "A"."bId" = "B_1"."id" LEFT JOIN "A" AS "A_2" ON "B_1"."id" = "A_2"."bId" WHERE "A"."id" = ?1`).bind(id),
-            async get(env: Env, id: number): Promise<CloesceResult<A.Self | null>> {
+            getQuery: (env: { db: Env["db"] }, id: number) => env.db.prepare(`SELECT "A"."id" AS "id", "A"."bId" AS "bId", "B_1"."id" AS "b.id", "A_2"."id" AS "b.a.id", "A_2"."bId" AS "b.a.bId" FROM "A" LEFT JOIN "B" AS "B_1" ON "A"."bId" = "B_1"."id" LEFT JOIN "A" AS "A_2" ON "B_1"."id" = "A_2"."bId" WHERE "A"."id" = ?1`).bind(id),
+            async get(env: { db: Env["db"] }, id: number): Promise<CloesceResult<A.Self | null>> {
                 return await CloesceOrm.fromEnv(env).get<A.Self>(A.Meta, A.Source.Default.getQuery(env, id), A.Source.Default.include, {  });
             },
-            listQuery: (env: Env, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "A"."id" AS "id", "A"."bId" AS "bId", "B_1"."id" AS "b.id", "A_2"."id" AS "b.a.id", "A_2"."bId" AS "b.a.bId" FROM "A" LEFT JOIN "B" AS "B_1" ON "A"."bId" = "B_1"."id" LEFT JOIN "A" AS "A_2" ON "B_1"."id" = "A_2"."bId" WHERE "A"."id" > ?1 ORDER BY "A"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
-            async list(env: Env, lastSeen_id: number, limit: number): Promise<CloesceResult<A.Self[]>> {
+            listQuery: (env: { db: Env["db"] }, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "A"."id" AS "id", "A"."bId" AS "bId", "B_1"."id" AS "b.id", "A_2"."id" AS "b.a.id", "A_2"."bId" AS "b.a.bId" FROM "A" LEFT JOIN "B" AS "B_1" ON "A"."bId" = "B_1"."id" LEFT JOIN "A" AS "A_2" ON "B_1"."id" = "A_2"."bId" WHERE "A"."id" > ?1 ORDER BY "A"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
+            async list(env: { db: Env["db"] }, lastSeen_id: number, limit: number): Promise<CloesceResult<A.Self[]>> {
                 return await CloesceOrm.fromEnv(env).list<A.Self>(A.Meta, A.Source.Default.listQuery(env, lastSeen_id, limit), A.Source.Default.include);
             },
         }
         export const WithB = {
             include: {"b":{}},
-            getQuery: (env: Env, id: number) => env.db.prepare(`SELECT "A"."id" AS "id", "A"."bId" AS "bId", "B_1"."id" AS "b.id" FROM "A" LEFT JOIN "B" AS "B_1" ON "A"."bId" = "B_1"."id" WHERE "A"."id" = ?1`).bind(id),
-            async get(env: Env, id: number): Promise<CloesceResult<A.Self | null>> {
+            getQuery: (env: { db: Env["db"] }, id: number) => env.db.prepare(`SELECT "A"."id" AS "id", "A"."bId" AS "bId", "B_1"."id" AS "b.id" FROM "A" LEFT JOIN "B" AS "B_1" ON "A"."bId" = "B_1"."id" WHERE "A"."id" = ?1`).bind(id),
+            async get(env: { db: Env["db"] }, id: number): Promise<CloesceResult<A.Self | null>> {
                 return await CloesceOrm.fromEnv(env).get<A.Self>(A.Meta, A.Source.WithB.getQuery(env, id), A.Source.WithB.include, {  });
             },
-            listQuery: (env: Env, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "A"."id" AS "id", "A"."bId" AS "bId", "B_1"."id" AS "b.id" FROM "A" LEFT JOIN "B" AS "B_1" ON "A"."bId" = "B_1"."id" WHERE "A"."id" > ?1 ORDER BY "A"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
-            async list(env: Env, lastSeen_id: number, limit: number): Promise<CloesceResult<A.Self[]>> {
+            listQuery: (env: { db: Env["db"] }, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "A"."id" AS "id", "A"."bId" AS "bId", "B_1"."id" AS "b.id" FROM "A" LEFT JOIN "B" AS "B_1" ON "A"."bId" = "B_1"."id" WHERE "A"."id" > ?1 ORDER BY "A"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
+            async list(env: { db: Env["db"] }, lastSeen_id: number, limit: number): Promise<CloesceResult<A.Self[]>> {
                 return await CloesceOrm.fromEnv(env).list<A.Self>(A.Meta, A.Source.WithB.listQuery(env, lastSeen_id, limit), A.Source.WithB.include);
             },
         }
         export const WithoutB = {
             include: {},
-            getQuery: (env: Env, id: number) => env.db.prepare(`SELECT "A"."id" AS "id", "A"."bId" AS "bId" FROM "A" WHERE "A"."id" = ?1`).bind(id),
-            async get(env: Env, id: number): Promise<CloesceResult<A.Self | null>> {
+            getQuery: (env: { db: Env["db"] }, id: number) => env.db.prepare(`SELECT "A"."id" AS "id", "A"."bId" AS "bId" FROM "A" WHERE "A"."id" = ?1`).bind(id),
+            async get(env: { db: Env["db"] }, id: number): Promise<CloesceResult<A.Self | null>> {
                 return await CloesceOrm.fromEnv(env).get<A.Self>(A.Meta, A.Source.WithoutB.getQuery(env, id), A.Source.WithoutB.include, {  });
             },
-            listQuery: (env: Env, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "A"."id" AS "id", "A"."bId" AS "bId" FROM "A" WHERE "A"."id" > ?1 ORDER BY "A"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
-            async list(env: Env, lastSeen_id: number, limit: number): Promise<CloesceResult<A.Self[]>> {
+            listQuery: (env: { db: Env["db"] }, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "A"."id" AS "id", "A"."bId" AS "bId" FROM "A" WHERE "A"."id" > ?1 ORDER BY "A"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
+            async list(env: { db: Env["db"] }, lastSeen_id: number, limit: number): Promise<CloesceResult<A.Self[]>> {
                 return await CloesceOrm.fromEnv(env).list<A.Self>(A.Meta, A.Source.WithoutB.listQuery(env, lastSeen_id, limit), A.Source.WithoutB.include);
             },
         }
     }
 
     export namespace Orm {
-        export async function save(env: Env, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
+        export async function save(env: { db: Env["db"] }, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
             return await CloesceOrm.fromEnv(env).upsert<Self>(Meta, newModel, include);
         }
 
-        export async function get(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Self | null>> {
+        export async function get(env: { db: Env["db"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Self | null>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).get<Self>(Meta, args.query, args.include, {});
         }
 
-        export async function list(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<A.Self[]>> {
+        export async function list(env: { db: Env["db"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<A.Self[]>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).list<Self>(Meta, args.query, args.include);
         }
@@ -101,7 +99,7 @@ export namespace A {
             return CloesceOrm.map<Self>(Meta, result, Source.Default.include);
         }
 
-        export async function hydrate(env: Env, base: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
+        export async function hydrate(env: { db: Env["db"] }, base: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
             return await CloesceOrm.fromEnv(env).hydrate<Self>(Meta, base, {  }, include);
         }
     }
@@ -120,7 +118,6 @@ export namespace B {
     }
 
     export interface Api {
-
         testMethod(
             self: B.Self,
         ): ApiResult<void>;
@@ -134,28 +131,28 @@ export namespace B {
     export namespace Source {
         export const Default = {
             include: {"a":{}},
-            getQuery: (env: Env, id: number) => env.db.prepare(`SELECT "B"."id" AS "id", "A_1"."id" AS "a.id", "A_1"."bId" AS "a.bId" FROM "B" LEFT JOIN "A" AS "A_1" ON "B"."id" = "A_1"."bId" WHERE "B"."id" = ?1`).bind(id),
-            async get(env: Env, id: number): Promise<CloesceResult<B.Self | null>> {
+            getQuery: (env: { db: Env["db"] }, id: number) => env.db.prepare(`SELECT "B"."id" AS "id", "A_1"."id" AS "a.id", "A_1"."bId" AS "a.bId" FROM "B" LEFT JOIN "A" AS "A_1" ON "B"."id" = "A_1"."bId" WHERE "B"."id" = ?1`).bind(id),
+            async get(env: { db: Env["db"] }, id: number): Promise<CloesceResult<B.Self | null>> {
                 return await CloesceOrm.fromEnv(env).get<B.Self>(B.Meta, B.Source.Default.getQuery(env, id), B.Source.Default.include, {  });
             },
-            listQuery: (env: Env, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "B"."id" AS "id", "A_1"."id" AS "a.id", "A_1"."bId" AS "a.bId" FROM "B" LEFT JOIN "A" AS "A_1" ON "B"."id" = "A_1"."bId" WHERE "B"."id" > ?1 ORDER BY "B"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
-            async list(env: Env, lastSeen_id: number, limit: number): Promise<CloesceResult<B.Self[]>> {
+            listQuery: (env: { db: Env["db"] }, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "B"."id" AS "id", "A_1"."id" AS "a.id", "A_1"."bId" AS "a.bId" FROM "B" LEFT JOIN "A" AS "A_1" ON "B"."id" = "A_1"."bId" WHERE "B"."id" > ?1 ORDER BY "B"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
+            async list(env: { db: Env["db"] }, lastSeen_id: number, limit: number): Promise<CloesceResult<B.Self[]>> {
                 return await CloesceOrm.fromEnv(env).list<B.Self>(B.Meta, B.Source.Default.listQuery(env, lastSeen_id, limit), B.Source.Default.include);
             },
         }
     }
 
     export namespace Orm {
-        export async function save(env: Env, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
+        export async function save(env: { db: Env["db"] }, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
             return await CloesceOrm.fromEnv(env).upsert<Self>(Meta, newModel, include);
         }
 
-        export async function get(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Self | null>> {
+        export async function get(env: { db: Env["db"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Self | null>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).get<Self>(Meta, args.query, args.include, {});
         }
 
-        export async function list(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<B.Self[]>> {
+        export async function list(env: { db: Env["db"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<B.Self[]>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).list<Self>(Meta, args.query, args.include);
         }
@@ -168,7 +165,7 @@ export namespace B {
             return CloesceOrm.map<Self>(Meta, result, Source.Default.include);
         }
 
-        export async function hydrate(env: Env, base: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
+        export async function hydrate(env: { db: Env["db"] }, base: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
             return await CloesceOrm.fromEnv(env).hydrate<Self>(Meta, base, {  }, include);
         }
     }
@@ -197,28 +194,28 @@ export namespace Course {
     export namespace Source {
         export const Default = {
             include: {"students":{}},
-            getQuery: (env: Env, id: number) => env.db.prepare(`SELECT "Course"."id" AS "id", "CourseStudent_2"."right" AS "students.id" FROM "Course" LEFT JOIN "CourseStudent" AS "CourseStudent_2" ON "Course"."id" = "CourseStudent_2"."left" LEFT JOIN "Student" AS "Student_1" ON "CourseStudent_2"."right" = "Student_1"."id" WHERE "Course"."id" = ?1`).bind(id),
-            async get(env: Env, id: number): Promise<CloesceResult<Course.Self | null>> {
+            getQuery: (env: { db: Env["db"] }, id: number) => env.db.prepare(`SELECT "Course"."id" AS "id", "CourseStudent_2"."right" AS "students.id" FROM "Course" LEFT JOIN "CourseStudent" AS "CourseStudent_2" ON "Course"."id" = "CourseStudent_2"."left" LEFT JOIN "Student" AS "Student_1" ON "CourseStudent_2"."right" = "Student_1"."id" WHERE "Course"."id" = ?1`).bind(id),
+            async get(env: { db: Env["db"] }, id: number): Promise<CloesceResult<Course.Self | null>> {
                 return await CloesceOrm.fromEnv(env).get<Course.Self>(Course.Meta, Course.Source.Default.getQuery(env, id), Course.Source.Default.include, {  });
             },
-            listQuery: (env: Env, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "Course"."id" AS "id", "CourseStudent_2"."right" AS "students.id" FROM "Course" LEFT JOIN "CourseStudent" AS "CourseStudent_2" ON "Course"."id" = "CourseStudent_2"."left" LEFT JOIN "Student" AS "Student_1" ON "CourseStudent_2"."right" = "Student_1"."id" WHERE "Course"."id" > ?1 ORDER BY "Course"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
-            async list(env: Env, lastSeen_id: number, limit: number): Promise<CloesceResult<Course.Self[]>> {
+            listQuery: (env: { db: Env["db"] }, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "Course"."id" AS "id", "CourseStudent_2"."right" AS "students.id" FROM "Course" LEFT JOIN "CourseStudent" AS "CourseStudent_2" ON "Course"."id" = "CourseStudent_2"."left" LEFT JOIN "Student" AS "Student_1" ON "CourseStudent_2"."right" = "Student_1"."id" WHERE "Course"."id" > ?1 ORDER BY "Course"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
+            async list(env: { db: Env["db"] }, lastSeen_id: number, limit: number): Promise<CloesceResult<Course.Self[]>> {
                 return await CloesceOrm.fromEnv(env).list<Course.Self>(Course.Meta, Course.Source.Default.listQuery(env, lastSeen_id, limit), Course.Source.Default.include);
             },
         }
     }
 
     export namespace Orm {
-        export async function save(env: Env, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
+        export async function save(env: { db: Env["db"] }, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
             return await CloesceOrm.fromEnv(env).upsert<Self>(Meta, newModel, include);
         }
 
-        export async function get(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Self | null>> {
+        export async function get(env: { db: Env["db"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Self | null>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).get<Self>(Meta, args.query, args.include, {});
         }
 
-        export async function list(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Course.Self[]>> {
+        export async function list(env: { db: Env["db"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Course.Self[]>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).list<Self>(Meta, args.query, args.include);
         }
@@ -231,7 +228,7 @@ export namespace Course {
             return CloesceOrm.map<Self>(Meta, result, Source.Default.include);
         }
 
-        export async function hydrate(env: Env, base: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
+        export async function hydrate(env: { db: Env["db"] }, base: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
             return await CloesceOrm.fromEnv(env).hydrate<Self>(Meta, base, {  }, include);
         }
     }
@@ -250,14 +247,12 @@ export namespace Person {
     }
 
     export interface Api {
-
         create(
             env: {
                 db: Env["db"],
             },
             person: Person.Self,
         ): ApiResult<Person.Self>;
-
         withoutDogs(
             self: Person.Self,
         ): ApiResult<Person.Self>;
@@ -271,50 +266,50 @@ export namespace Person {
     export namespace Source {
         export const Default = {
             include: {"dogs":{}},
-            getQuery: (env: Env, id: number) => env.db.prepare(`SELECT "Person"."id" AS "id", "Dog_1"."id" AS "dogs.id", "Dog_1"."personId" AS "dogs.personId" FROM "Person" LEFT JOIN "Dog" AS "Dog_1" ON "Person"."id" = "Dog_1"."personId" WHERE "Person"."id" = ?1`).bind(id),
-            async get(env: Env, id: number): Promise<CloesceResult<Person.Self | null>> {
+            getQuery: (env: { db: Env["db"] }, id: number) => env.db.prepare(`SELECT "Person"."id" AS "id", "Dog_1"."id" AS "dogs.id", "Dog_1"."personId" AS "dogs.personId" FROM "Person" LEFT JOIN "Dog" AS "Dog_1" ON "Person"."id" = "Dog_1"."personId" WHERE "Person"."id" = ?1`).bind(id),
+            async get(env: { db: Env["db"] }, id: number): Promise<CloesceResult<Person.Self | null>> {
                 return await CloesceOrm.fromEnv(env).get<Person.Self>(Person.Meta, Person.Source.Default.getQuery(env, id), Person.Source.Default.include, {  });
             },
-            listQuery: (env: Env, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "Person"."id" AS "id", "Dog_1"."id" AS "dogs.id", "Dog_1"."personId" AS "dogs.personId" FROM "Person" LEFT JOIN "Dog" AS "Dog_1" ON "Person"."id" = "Dog_1"."personId" WHERE "Person"."id" > ?1 ORDER BY "Person"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
-            async list(env: Env, lastSeen_id: number, limit: number): Promise<CloesceResult<Person.Self[]>> {
+            listQuery: (env: { db: Env["db"] }, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "Person"."id" AS "id", "Dog_1"."id" AS "dogs.id", "Dog_1"."personId" AS "dogs.personId" FROM "Person" LEFT JOIN "Dog" AS "Dog_1" ON "Person"."id" = "Dog_1"."personId" WHERE "Person"."id" > ?1 ORDER BY "Person"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
+            async list(env: { db: Env["db"] }, lastSeen_id: number, limit: number): Promise<CloesceResult<Person.Self[]>> {
                 return await CloesceOrm.fromEnv(env).list<Person.Self>(Person.Meta, Person.Source.Default.listQuery(env, lastSeen_id, limit), Person.Source.Default.include);
             },
         }
         export const WithDogs = {
             include: {"dogs":{}},
-            getQuery: (env: Env, id: number) => env.db.prepare(`SELECT "Person"."id" AS "id", "Dog_1"."id" AS "dogs.id", "Dog_1"."personId" AS "dogs.personId" FROM "Person" LEFT JOIN "Dog" AS "Dog_1" ON "Person"."id" = "Dog_1"."personId" WHERE "Person"."id" = ?1`).bind(id),
-            async get(env: Env, id: number): Promise<CloesceResult<Person.Self | null>> {
+            getQuery: (env: { db: Env["db"] }, id: number) => env.db.prepare(`SELECT "Person"."id" AS "id", "Dog_1"."id" AS "dogs.id", "Dog_1"."personId" AS "dogs.personId" FROM "Person" LEFT JOIN "Dog" AS "Dog_1" ON "Person"."id" = "Dog_1"."personId" WHERE "Person"."id" = ?1`).bind(id),
+            async get(env: { db: Env["db"] }, id: number): Promise<CloesceResult<Person.Self | null>> {
                 return await CloesceOrm.fromEnv(env).get<Person.Self>(Person.Meta, Person.Source.WithDogs.getQuery(env, id), Person.Source.WithDogs.include, {  });
             },
-            listQuery: (env: Env, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "Person"."id" AS "id", "Dog_1"."id" AS "dogs.id", "Dog_1"."personId" AS "dogs.personId" FROM "Person" LEFT JOIN "Dog" AS "Dog_1" ON "Person"."id" = "Dog_1"."personId" WHERE "Person"."id" > ?1 ORDER BY "Person"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
-            async list(env: Env, lastSeen_id: number, limit: number): Promise<CloesceResult<Person.Self[]>> {
+            listQuery: (env: { db: Env["db"] }, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "Person"."id" AS "id", "Dog_1"."id" AS "dogs.id", "Dog_1"."personId" AS "dogs.personId" FROM "Person" LEFT JOIN "Dog" AS "Dog_1" ON "Person"."id" = "Dog_1"."personId" WHERE "Person"."id" > ?1 ORDER BY "Person"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
+            async list(env: { db: Env["db"] }, lastSeen_id: number, limit: number): Promise<CloesceResult<Person.Self[]>> {
                 return await CloesceOrm.fromEnv(env).list<Person.Self>(Person.Meta, Person.Source.WithDogs.listQuery(env, lastSeen_id, limit), Person.Source.WithDogs.include);
             },
         }
         export const WithoutDogs = {
             include: {},
-            getQuery: (env: Env, id: number) => env.db.prepare(`SELECT "Person"."id" AS "id" FROM "Person" WHERE "Person"."id" = ?1`).bind(id),
-            async get(env: Env, id: number): Promise<CloesceResult<Person.Self | null>> {
+            getQuery: (env: { db: Env["db"] }, id: number) => env.db.prepare(`SELECT "Person"."id" AS "id" FROM "Person" WHERE "Person"."id" = ?1`).bind(id),
+            async get(env: { db: Env["db"] }, id: number): Promise<CloesceResult<Person.Self | null>> {
                 return await CloesceOrm.fromEnv(env).get<Person.Self>(Person.Meta, Person.Source.WithoutDogs.getQuery(env, id), Person.Source.WithoutDogs.include, {  });
             },
-            listQuery: (env: Env, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "Person"."id" AS "id" FROM "Person" WHERE "Person"."id" > ?1 ORDER BY "Person"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
-            async list(env: Env, lastSeen_id: number, limit: number): Promise<CloesceResult<Person.Self[]>> {
+            listQuery: (env: { db: Env["db"] }, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "Person"."id" AS "id" FROM "Person" WHERE "Person"."id" > ?1 ORDER BY "Person"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
+            async list(env: { db: Env["db"] }, lastSeen_id: number, limit: number): Promise<CloesceResult<Person.Self[]>> {
                 return await CloesceOrm.fromEnv(env).list<Person.Self>(Person.Meta, Person.Source.WithoutDogs.listQuery(env, lastSeen_id, limit), Person.Source.WithoutDogs.include);
             },
         }
     }
 
     export namespace Orm {
-        export async function save(env: Env, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
+        export async function save(env: { db: Env["db"] }, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
             return await CloesceOrm.fromEnv(env).upsert<Self>(Meta, newModel, include);
         }
 
-        export async function get(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Self | null>> {
+        export async function get(env: { db: Env["db"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Self | null>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).get<Self>(Meta, args.query, args.include, {});
         }
 
-        export async function list(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Person.Self[]>> {
+        export async function list(env: { db: Env["db"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Person.Self[]>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).list<Self>(Meta, args.query, args.include);
         }
@@ -327,7 +322,7 @@ export namespace Person {
             return CloesceOrm.map<Self>(Meta, result, Source.Default.include);
         }
 
-        export async function hydrate(env: Env, base: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
+        export async function hydrate(env: { db: Env["db"] }, base: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
             return await CloesceOrm.fromEnv(env).hydrate<Self>(Meta, base, {  }, include);
         }
     }
@@ -346,14 +341,12 @@ export namespace Student {
     }
 
     export interface Api {
-
         create(
             env: {
                 db: Env["db"],
             },
             student: Student.Self,
         ): ApiResult<Student.Self>;
-
         none(
             self: Student.Self,
         ): ApiResult<Student.Self>;
@@ -367,50 +360,50 @@ export namespace Student {
     export namespace Source {
         export const Default = {
             include: {"courses":{}},
-            getQuery: (env: Env, id: number) => env.db.prepare(`SELECT "Student"."id" AS "id", "CourseStudent_2"."left" AS "courses.id" FROM "Student" LEFT JOIN "CourseStudent" AS "CourseStudent_2" ON "Student"."id" = "CourseStudent_2"."right" LEFT JOIN "Course" AS "Course_1" ON "CourseStudent_2"."left" = "Course_1"."id" WHERE "Student"."id" = ?1`).bind(id),
-            async get(env: Env, id: number): Promise<CloesceResult<Student.Self | null>> {
+            getQuery: (env: { db: Env["db"] }, id: number) => env.db.prepare(`SELECT "Student"."id" AS "id", "CourseStudent_2"."left" AS "courses.id" FROM "Student" LEFT JOIN "CourseStudent" AS "CourseStudent_2" ON "Student"."id" = "CourseStudent_2"."right" LEFT JOIN "Course" AS "Course_1" ON "CourseStudent_2"."left" = "Course_1"."id" WHERE "Student"."id" = ?1`).bind(id),
+            async get(env: { db: Env["db"] }, id: number): Promise<CloesceResult<Student.Self | null>> {
                 return await CloesceOrm.fromEnv(env).get<Student.Self>(Student.Meta, Student.Source.Default.getQuery(env, id), Student.Source.Default.include, {  });
             },
-            listQuery: (env: Env, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "Student"."id" AS "id", "CourseStudent_2"."left" AS "courses.id" FROM "Student" LEFT JOIN "CourseStudent" AS "CourseStudent_2" ON "Student"."id" = "CourseStudent_2"."right" LEFT JOIN "Course" AS "Course_1" ON "CourseStudent_2"."left" = "Course_1"."id" WHERE "Student"."id" > ?1 ORDER BY "Student"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
-            async list(env: Env, lastSeen_id: number, limit: number): Promise<CloesceResult<Student.Self[]>> {
+            listQuery: (env: { db: Env["db"] }, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "Student"."id" AS "id", "CourseStudent_2"."left" AS "courses.id" FROM "Student" LEFT JOIN "CourseStudent" AS "CourseStudent_2" ON "Student"."id" = "CourseStudent_2"."right" LEFT JOIN "Course" AS "Course_1" ON "CourseStudent_2"."left" = "Course_1"."id" WHERE "Student"."id" > ?1 ORDER BY "Student"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
+            async list(env: { db: Env["db"] }, lastSeen_id: number, limit: number): Promise<CloesceResult<Student.Self[]>> {
                 return await CloesceOrm.fromEnv(env).list<Student.Self>(Student.Meta, Student.Source.Default.listQuery(env, lastSeen_id, limit), Student.Source.Default.include);
             },
         }
         export const None = {
             include: {},
-            getQuery: (env: Env, id: number) => env.db.prepare(`SELECT "Student"."id" AS "id" FROM "Student" WHERE "Student"."id" = ?1`).bind(id),
-            async get(env: Env, id: number): Promise<CloesceResult<Student.Self | null>> {
+            getQuery: (env: { db: Env["db"] }, id: number) => env.db.prepare(`SELECT "Student"."id" AS "id" FROM "Student" WHERE "Student"."id" = ?1`).bind(id),
+            async get(env: { db: Env["db"] }, id: number): Promise<CloesceResult<Student.Self | null>> {
                 return await CloesceOrm.fromEnv(env).get<Student.Self>(Student.Meta, Student.Source.None.getQuery(env, id), Student.Source.None.include, {  });
             },
-            listQuery: (env: Env, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "Student"."id" AS "id" FROM "Student" WHERE "Student"."id" > ?1 ORDER BY "Student"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
-            async list(env: Env, lastSeen_id: number, limit: number): Promise<CloesceResult<Student.Self[]>> {
+            listQuery: (env: { db: Env["db"] }, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "Student"."id" AS "id" FROM "Student" WHERE "Student"."id" > ?1 ORDER BY "Student"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
+            async list(env: { db: Env["db"] }, lastSeen_id: number, limit: number): Promise<CloesceResult<Student.Self[]>> {
                 return await CloesceOrm.fromEnv(env).list<Student.Self>(Student.Meta, Student.Source.None.listQuery(env, lastSeen_id, limit), Student.Source.None.include);
             },
         }
         export const WithCoursesStudentsCourses = {
             include: {"courses":{"students":{"courses":{}}}},
-            getQuery: (env: Env, id: number) => env.db.prepare(`SELECT "Student"."id" AS "id", "CourseStudent_2"."left" AS "courses.id", "CourseStudent_4"."right" AS "courses.students.id", "CourseStudent_6"."left" AS "courses.students.courses.id" FROM "Student" LEFT JOIN "CourseStudent" AS "CourseStudent_2" ON "Student"."id" = "CourseStudent_2"."right" LEFT JOIN "Course" AS "Course_1" ON "CourseStudent_2"."left" = "Course_1"."id" LEFT JOIN "CourseStudent" AS "CourseStudent_4" ON "Course_1"."id" = "CourseStudent_4"."left" LEFT JOIN "Student" AS "Student_3" ON "CourseStudent_4"."right" = "Student_3"."id" LEFT JOIN "CourseStudent" AS "CourseStudent_6" ON "Student_3"."id" = "CourseStudent_6"."right" LEFT JOIN "Course" AS "Course_5" ON "CourseStudent_6"."left" = "Course_5"."id" WHERE "Student"."id" = ?1`).bind(id),
-            async get(env: Env, id: number): Promise<CloesceResult<Student.Self | null>> {
+            getQuery: (env: { db: Env["db"] }, id: number) => env.db.prepare(`SELECT "Student"."id" AS "id", "CourseStudent_2"."left" AS "courses.id", "CourseStudent_4"."right" AS "courses.students.id", "CourseStudent_6"."left" AS "courses.students.courses.id" FROM "Student" LEFT JOIN "CourseStudent" AS "CourseStudent_2" ON "Student"."id" = "CourseStudent_2"."right" LEFT JOIN "Course" AS "Course_1" ON "CourseStudent_2"."left" = "Course_1"."id" LEFT JOIN "CourseStudent" AS "CourseStudent_4" ON "Course_1"."id" = "CourseStudent_4"."left" LEFT JOIN "Student" AS "Student_3" ON "CourseStudent_4"."right" = "Student_3"."id" LEFT JOIN "CourseStudent" AS "CourseStudent_6" ON "Student_3"."id" = "CourseStudent_6"."right" LEFT JOIN "Course" AS "Course_5" ON "CourseStudent_6"."left" = "Course_5"."id" WHERE "Student"."id" = ?1`).bind(id),
+            async get(env: { db: Env["db"] }, id: number): Promise<CloesceResult<Student.Self | null>> {
                 return await CloesceOrm.fromEnv(env).get<Student.Self>(Student.Meta, Student.Source.WithCoursesStudentsCourses.getQuery(env, id), Student.Source.WithCoursesStudentsCourses.include, {  });
             },
-            listQuery: (env: Env, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "Student"."id" AS "id", "CourseStudent_2"."left" AS "courses.id", "CourseStudent_4"."right" AS "courses.students.id", "CourseStudent_6"."left" AS "courses.students.courses.id" FROM "Student" LEFT JOIN "CourseStudent" AS "CourseStudent_2" ON "Student"."id" = "CourseStudent_2"."right" LEFT JOIN "Course" AS "Course_1" ON "CourseStudent_2"."left" = "Course_1"."id" LEFT JOIN "CourseStudent" AS "CourseStudent_4" ON "Course_1"."id" = "CourseStudent_4"."left" LEFT JOIN "Student" AS "Student_3" ON "CourseStudent_4"."right" = "Student_3"."id" LEFT JOIN "CourseStudent" AS "CourseStudent_6" ON "Student_3"."id" = "CourseStudent_6"."right" LEFT JOIN "Course" AS "Course_5" ON "CourseStudent_6"."left" = "Course_5"."id" WHERE "Student"."id" > ?1 ORDER BY "Student"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
-            async list(env: Env, lastSeen_id: number, limit: number): Promise<CloesceResult<Student.Self[]>> {
+            listQuery: (env: { db: Env["db"] }, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "Student"."id" AS "id", "CourseStudent_2"."left" AS "courses.id", "CourseStudent_4"."right" AS "courses.students.id", "CourseStudent_6"."left" AS "courses.students.courses.id" FROM "Student" LEFT JOIN "CourseStudent" AS "CourseStudent_2" ON "Student"."id" = "CourseStudent_2"."right" LEFT JOIN "Course" AS "Course_1" ON "CourseStudent_2"."left" = "Course_1"."id" LEFT JOIN "CourseStudent" AS "CourseStudent_4" ON "Course_1"."id" = "CourseStudent_4"."left" LEFT JOIN "Student" AS "Student_3" ON "CourseStudent_4"."right" = "Student_3"."id" LEFT JOIN "CourseStudent" AS "CourseStudent_6" ON "Student_3"."id" = "CourseStudent_6"."right" LEFT JOIN "Course" AS "Course_5" ON "CourseStudent_6"."left" = "Course_5"."id" WHERE "Student"."id" > ?1 ORDER BY "Student"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
+            async list(env: { db: Env["db"] }, lastSeen_id: number, limit: number): Promise<CloesceResult<Student.Self[]>> {
                 return await CloesceOrm.fromEnv(env).list<Student.Self>(Student.Meta, Student.Source.WithCoursesStudentsCourses.listQuery(env, lastSeen_id, limit), Student.Source.WithCoursesStudentsCourses.include);
             },
         }
     }
 
     export namespace Orm {
-        export async function save(env: Env, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
+        export async function save(env: { db: Env["db"] }, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
             return await CloesceOrm.fromEnv(env).upsert<Self>(Meta, newModel, include);
         }
 
-        export async function get(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Self | null>> {
+        export async function get(env: { db: Env["db"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Self | null>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).get<Self>(Meta, args.query, args.include, {});
         }
 
-        export async function list(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Student.Self[]>> {
+        export async function list(env: { db: Env["db"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Student.Self[]>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).list<Self>(Meta, args.query, args.include);
         }
@@ -423,7 +416,7 @@ export namespace Student {
             return CloesceOrm.map<Self>(Meta, result, Source.Default.include);
         }
 
-        export async function hydrate(env: Env, base: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
+        export async function hydrate(env: { db: Env["db"] }, base: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
             return await CloesceOrm.fromEnv(env).hydrate<Self>(Meta, base, {  }, include);
         }
     }
@@ -443,7 +436,6 @@ export namespace Dog {
     }
 
     export interface Api {
-
         testMethod(
             self: Dog.Self,
         ): ApiResult<void>;
@@ -457,28 +449,28 @@ export namespace Dog {
     export namespace Source {
         export const Default = {
             include: {"person":{"dogs":{}}},
-            getQuery: (env: Env, id: number) => env.db.prepare(`SELECT "Dog"."id" AS "id", "Dog"."personId" AS "personId", "Person_1"."id" AS "person.id", "Dog_2"."id" AS "person.dogs.id", "Dog_2"."personId" AS "person.dogs.personId" FROM "Dog" LEFT JOIN "Person" AS "Person_1" ON "Dog"."personId" = "Person_1"."id" LEFT JOIN "Dog" AS "Dog_2" ON "Person_1"."id" = "Dog_2"."personId" WHERE "Dog"."id" = ?1`).bind(id),
-            async get(env: Env, id: number): Promise<CloesceResult<Dog.Self | null>> {
+            getQuery: (env: { db: Env["db"] }, id: number) => env.db.prepare(`SELECT "Dog"."id" AS "id", "Dog"."personId" AS "personId", "Person_1"."id" AS "person.id", "Dog_2"."id" AS "person.dogs.id", "Dog_2"."personId" AS "person.dogs.personId" FROM "Dog" LEFT JOIN "Person" AS "Person_1" ON "Dog"."personId" = "Person_1"."id" LEFT JOIN "Dog" AS "Dog_2" ON "Person_1"."id" = "Dog_2"."personId" WHERE "Dog"."id" = ?1`).bind(id),
+            async get(env: { db: Env["db"] }, id: number): Promise<CloesceResult<Dog.Self | null>> {
                 return await CloesceOrm.fromEnv(env).get<Dog.Self>(Dog.Meta, Dog.Source.Default.getQuery(env, id), Dog.Source.Default.include, {  });
             },
-            listQuery: (env: Env, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "Dog"."id" AS "id", "Dog"."personId" AS "personId", "Person_1"."id" AS "person.id", "Dog_2"."id" AS "person.dogs.id", "Dog_2"."personId" AS "person.dogs.personId" FROM "Dog" LEFT JOIN "Person" AS "Person_1" ON "Dog"."personId" = "Person_1"."id" LEFT JOIN "Dog" AS "Dog_2" ON "Person_1"."id" = "Dog_2"."personId" WHERE "Dog"."id" > ?1 ORDER BY "Dog"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
-            async list(env: Env, lastSeen_id: number, limit: number): Promise<CloesceResult<Dog.Self[]>> {
+            listQuery: (env: { db: Env["db"] }, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "Dog"."id" AS "id", "Dog"."personId" AS "personId", "Person_1"."id" AS "person.id", "Dog_2"."id" AS "person.dogs.id", "Dog_2"."personId" AS "person.dogs.personId" FROM "Dog" LEFT JOIN "Person" AS "Person_1" ON "Dog"."personId" = "Person_1"."id" LEFT JOIN "Dog" AS "Dog_2" ON "Person_1"."id" = "Dog_2"."personId" WHERE "Dog"."id" > ?1 ORDER BY "Dog"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
+            async list(env: { db: Env["db"] }, lastSeen_id: number, limit: number): Promise<CloesceResult<Dog.Self[]>> {
                 return await CloesceOrm.fromEnv(env).list<Dog.Self>(Dog.Meta, Dog.Source.Default.listQuery(env, lastSeen_id, limit), Dog.Source.Default.include);
             },
         }
     }
 
     export namespace Orm {
-        export async function save(env: Env, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
+        export async function save(env: { db: Env["db"] }, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
             return await CloesceOrm.fromEnv(env).upsert<Self>(Meta, newModel, include);
         }
 
-        export async function get(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Self | null>> {
+        export async function get(env: { db: Env["db"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Self | null>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).get<Self>(Meta, args.query, args.include, {});
         }
 
-        export async function list(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Dog.Self[]>> {
+        export async function list(env: { db: Env["db"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Dog.Self[]>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).list<Self>(Meta, args.query, args.include);
         }
@@ -491,7 +483,7 @@ export namespace Dog {
             return CloesceOrm.map<Self>(Meta, result, Source.Default.include);
         }
 
-        export async function hydrate(env: Env, base: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
+        export async function hydrate(env: { db: Env["db"] }, base: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
             return await CloesceOrm.fromEnv(env).hydrate<Self>(Meta, base, {  }, include);
         }
     }

--- a/tests/e2e/fixtures/kv/backend.ts
+++ b/tests/e2e/fixtures/kv/backend.ts
@@ -41,28 +41,28 @@ export namespace D1BackedModel {
     export namespace Source {
         export const Default = {
             include: {"kvData":{}},
-            getQuery: (env: Env, id: number) => env.db.prepare(`SELECT "D1BackedModel"."id" AS "id", "D1BackedModel"."someColumn" AS "someColumn", "D1BackedModel"."someOtherColumn" AS "someOtherColumn" FROM "D1BackedModel" WHERE "D1BackedModel"."id" = ?1`).bind(id),
-            async get(env: Env, id: number, keyParam: string): Promise<CloesceResult<D1BackedModel.Self | null>> {
+            getQuery: (env: { db: Env["db"], namespace: Env["namespace"] }, id: number) => env.db.prepare(`SELECT "D1BackedModel"."id" AS "id", "D1BackedModel"."someColumn" AS "someColumn", "D1BackedModel"."someOtherColumn" AS "someOtherColumn" FROM "D1BackedModel" WHERE "D1BackedModel"."id" = ?1`).bind(id),
+            async get(env: { db: Env["db"], namespace: Env["namespace"] }, id: number, keyParam: string): Promise<CloesceResult<D1BackedModel.Self | null>> {
                 return await CloesceOrm.fromEnv(env).get<D1BackedModel.Self>(D1BackedModel.Meta, D1BackedModel.Source.Default.getQuery(env, id), D1BackedModel.Source.Default.include, { keyParam });
             },
-            listQuery: (env: Env, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "D1BackedModel"."id" AS "id", "D1BackedModel"."someColumn" AS "someColumn", "D1BackedModel"."someOtherColumn" AS "someOtherColumn" FROM "D1BackedModel" WHERE "D1BackedModel"."id" > ?1 ORDER BY "D1BackedModel"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
-            async list(env: Env, lastSeen_id: number, limit: number): Promise<CloesceResult<D1BackedModel.Self[]>> {
+            listQuery: (env: { db: Env["db"], namespace: Env["namespace"] }, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "D1BackedModel"."id" AS "id", "D1BackedModel"."someColumn" AS "someColumn", "D1BackedModel"."someOtherColumn" AS "someOtherColumn" FROM "D1BackedModel" WHERE "D1BackedModel"."id" > ?1 ORDER BY "D1BackedModel"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
+            async list(env: { db: Env["db"], namespace: Env["namespace"] }, lastSeen_id: number, limit: number): Promise<CloesceResult<D1BackedModel.Self[]>> {
                 return await CloesceOrm.fromEnv(env).list<D1BackedModel.Self>(D1BackedModel.Meta, D1BackedModel.Source.Default.listQuery(env, lastSeen_id, limit), D1BackedModel.Source.Default.include);
             },
         }
     }
 
     export namespace Orm {
-        export async function save(env: Env, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
+        export async function save(env: { db: Env["db"], namespace: Env["namespace"] }, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
             return await CloesceOrm.fromEnv(env).upsert<Self>(Meta, newModel, include);
         }
 
-        export async function get(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self>, keyFields?: { keyParam?: string } }): Promise<CloesceResult<Self | null>> {
+        export async function get(env: { db: Env["db"], namespace: Env["namespace"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self>, keyFields?: { keyParam?: string } }): Promise<CloesceResult<Self | null>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).get<Self>(Meta, args.query, args.include, args.keyFields ?? {});
         }
 
-        export async function list(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<D1BackedModel.Self[]>> {
+        export async function list(env: { db: Env["db"], namespace: Env["namespace"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<D1BackedModel.Self[]>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).list<Self>(Meta, args.query, args.include);
         }
@@ -75,7 +75,7 @@ export namespace D1BackedModel {
             return CloesceOrm.map<Self>(Meta, result, Source.Default.include);
         }
 
-        export async function hydrate(env: Env, base: DeepPartial<Self>, keyParam: string, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
+        export async function hydrate(env: { db: Env["db"], namespace: Env["namespace"] }, base: DeepPartial<Self>, keyParam: string, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
             return await CloesceOrm.fromEnv(env).hydrate<Self>(Meta, base, { keyParam }, include);
         }
     }
@@ -97,7 +97,6 @@ export namespace PaginatedKVModel {
     }
 
     export interface Api {
-
         acceptPaginated(
             ps: Paginated<KValue<unknown>>,
         ): ApiResult<Paginated<KValue<unknown>>>;
@@ -111,23 +110,23 @@ export namespace PaginatedKVModel {
     export namespace Source {
         export const Default = {
             include: {"items":{}},
-            async get(env: Env, id: string): Promise<PaginatedKVModel.Self | null> {
+            async get(env: { namespace: Env["namespace"] }, id: string): Promise<PaginatedKVModel.Self | null> {
                 return await CloesceOrm.fromEnv(env).get<PaginatedKVModel.Self>(PaginatedKVModel.Meta, null, PaginatedKVModel.Source.Default.include, { id });
             },
         }
     }
 
     export namespace Orm {
-        export async function save(env: Env, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
+        export async function save(env: { namespace: Env["namespace"] }, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
             return await CloesceOrm.fromEnv(env).upsert<Self>(Meta, newModel, include);
         }
 
-        export async function get(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self>, keyFields?: { id?: string } }): Promise<CloesceResult<Self | null>> {
+        export async function get(env: { namespace: Env["namespace"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self>, keyFields?: { id?: string } }): Promise<CloesceResult<Self | null>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).get<Self>(Meta, args.query, args.include, args.keyFields ?? {});
         }
 
-        export async function list(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<PaginatedKVModel.Self[]>> {
+        export async function list(env: { namespace: Env["namespace"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<PaginatedKVModel.Self[]>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).list<Self>(Meta, args.query, args.include);
         }
@@ -140,7 +139,7 @@ export namespace PaginatedKVModel {
             return CloesceOrm.map<Self>(Meta, result, Source.Default.include);
         }
 
-        export async function hydrate(env: Env, base: DeepPartial<Self>, id: string, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
+        export async function hydrate(env: { namespace: Env["namespace"] }, base: DeepPartial<Self>, id: string, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
             return await CloesceOrm.fromEnv(env).hydrate<Self>(Meta, base, { id }, include);
         }
     }
@@ -176,23 +175,23 @@ export namespace PureKVModel {
     export namespace Source {
         export const Default = {
             include: {"data":{},"otherData":{}},
-            async get(env: Env, id: string): Promise<PureKVModel.Self | null> {
+            async get(env: { namespace: Env["namespace"], otherNamespace: Env["otherNamespace"] }, id: string): Promise<PureKVModel.Self | null> {
                 return await CloesceOrm.fromEnv(env).get<PureKVModel.Self>(PureKVModel.Meta, null, PureKVModel.Source.Default.include, { id });
             },
         }
     }
 
     export namespace Orm {
-        export async function save(env: Env, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
+        export async function save(env: { namespace: Env["namespace"], otherNamespace: Env["otherNamespace"] }, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
             return await CloesceOrm.fromEnv(env).upsert<Self>(Meta, newModel, include);
         }
 
-        export async function get(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self>, keyFields?: { id?: string } }): Promise<CloesceResult<Self | null>> {
+        export async function get(env: { namespace: Env["namespace"], otherNamespace: Env["otherNamespace"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self>, keyFields?: { id?: string } }): Promise<CloesceResult<Self | null>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).get<Self>(Meta, args.query, args.include, args.keyFields ?? {});
         }
 
-        export async function list(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<PureKVModel.Self[]>> {
+        export async function list(env: { namespace: Env["namespace"], otherNamespace: Env["otherNamespace"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<PureKVModel.Self[]>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).list<Self>(Meta, args.query, args.include);
         }
@@ -205,7 +204,7 @@ export namespace PureKVModel {
             return CloesceOrm.map<Self>(Meta, result, Source.Default.include);
         }
 
-        export async function hydrate(env: Env, base: DeepPartial<Self>, id: string, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
+        export async function hydrate(env: { namespace: Env["namespace"], otherNamespace: Env["otherNamespace"] }, base: DeepPartial<Self>, id: string, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
             return await CloesceOrm.fromEnv(env).hydrate<Self>(Meta, base, { id }, include);
         }
     }

--- a/tests/e2e/fixtures/middleware/backend.ts
+++ b/tests/e2e/fixtures/middleware/backend.ts
@@ -25,10 +25,8 @@ export namespace Foo {
     }
 
     export interface Api {
-
         blockedMethod(
         ): ApiResult<void>;
-
         getInjectedThing(
             env: {
                 InjectedThing: InjectedThing,
@@ -44,28 +42,28 @@ export namespace Foo {
     export namespace Source {
         export const Default = {
             include: {},
-            getQuery: (env: Env, id: string) => env.db.prepare(`SELECT "Foo"."id" AS "id" FROM "Foo" WHERE "Foo"."id" = ?1`).bind(id),
-            async get(env: Env, id: string): Promise<CloesceResult<Foo.Self | null>> {
+            getQuery: (env: { db: Env["db"] }, id: string) => env.db.prepare(`SELECT "Foo"."id" AS "id" FROM "Foo" WHERE "Foo"."id" = ?1`).bind(id),
+            async get(env: { db: Env["db"] }, id: string): Promise<CloesceResult<Foo.Self | null>> {
                 return await CloesceOrm.fromEnv(env).get<Foo.Self>(Foo.Meta, Foo.Source.Default.getQuery(env, id), Foo.Source.Default.include, {  });
             },
-            listQuery: (env: Env, lastSeen_id: string, limit: number) => env.db.prepare(`SELECT "Foo"."id" AS "id" FROM "Foo" WHERE "Foo"."id" > ?1 ORDER BY "Foo"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
-            async list(env: Env, lastSeen_id: string, limit: number): Promise<CloesceResult<Foo.Self[]>> {
+            listQuery: (env: { db: Env["db"] }, lastSeen_id: string, limit: number) => env.db.prepare(`SELECT "Foo"."id" AS "id" FROM "Foo" WHERE "Foo"."id" > ?1 ORDER BY "Foo"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
+            async list(env: { db: Env["db"] }, lastSeen_id: string, limit: number): Promise<CloesceResult<Foo.Self[]>> {
                 return await CloesceOrm.fromEnv(env).list<Foo.Self>(Foo.Meta, Foo.Source.Default.listQuery(env, lastSeen_id, limit), Foo.Source.Default.include);
             },
         }
     }
 
     export namespace Orm {
-        export async function save(env: Env, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
+        export async function save(env: { db: Env["db"] }, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
             return await CloesceOrm.fromEnv(env).upsert<Self>(Meta, newModel, include);
         }
 
-        export async function get(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Self | null>> {
+        export async function get(env: { db: Env["db"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Self | null>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).get<Self>(Meta, args.query, args.include, {});
         }
 
-        export async function list(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Foo.Self[]>> {
+        export async function list(env: { db: Env["db"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Foo.Self[]>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).list<Self>(Meta, args.query, args.include);
         }
@@ -78,7 +76,7 @@ export namespace Foo {
             return CloesceOrm.map<Self>(Meta, result, Source.Default.include);
         }
 
-        export async function hydrate(env: Env, base: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
+        export async function hydrate(env: { db: Env["db"] }, base: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
             return await CloesceOrm.fromEnv(env).hydrate<Self>(Meta, base, {  }, include);
         }
     }

--- a/tests/e2e/fixtures/multiple_db/backend.ts
+++ b/tests/e2e/fixtures/multiple_db/backend.ts
@@ -34,28 +34,28 @@ export namespace DB1Model {
     export namespace Source {
         export const Default = {
             include: {},
-            getQuery: (env: Env, id: number) => env.db1.prepare(`SELECT "DB1Model"."id" AS "id", "DB1Model"."someColumn" AS "someColumn" FROM "DB1Model" WHERE "DB1Model"."id" = ?1`).bind(id),
-            async get(env: Env, id: number): Promise<CloesceResult<DB1Model.Self | null>> {
+            getQuery: (env: { db1: Env["db1"] }, id: number) => env.db1.prepare(`SELECT "DB1Model"."id" AS "id", "DB1Model"."someColumn" AS "someColumn" FROM "DB1Model" WHERE "DB1Model"."id" = ?1`).bind(id),
+            async get(env: { db1: Env["db1"] }, id: number): Promise<CloesceResult<DB1Model.Self | null>> {
                 return await CloesceOrm.fromEnv(env).get<DB1Model.Self>(DB1Model.Meta, DB1Model.Source.Default.getQuery(env, id), DB1Model.Source.Default.include, {  });
             },
-            listQuery: (env: Env, lastSeen_id: number, limit: number) => env.db1.prepare(`SELECT "DB1Model"."id" AS "id", "DB1Model"."someColumn" AS "someColumn" FROM "DB1Model" WHERE "DB1Model"."id" > ?1 ORDER BY "DB1Model"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
-            async list(env: Env, lastSeen_id: number, limit: number): Promise<CloesceResult<DB1Model.Self[]>> {
+            listQuery: (env: { db1: Env["db1"] }, lastSeen_id: number, limit: number) => env.db1.prepare(`SELECT "DB1Model"."id" AS "id", "DB1Model"."someColumn" AS "someColumn" FROM "DB1Model" WHERE "DB1Model"."id" > ?1 ORDER BY "DB1Model"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
+            async list(env: { db1: Env["db1"] }, lastSeen_id: number, limit: number): Promise<CloesceResult<DB1Model.Self[]>> {
                 return await CloesceOrm.fromEnv(env).list<DB1Model.Self>(DB1Model.Meta, DB1Model.Source.Default.listQuery(env, lastSeen_id, limit), DB1Model.Source.Default.include);
             },
         }
     }
 
     export namespace Orm {
-        export async function save(env: Env, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
+        export async function save(env: { db1: Env["db1"] }, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
             return await CloesceOrm.fromEnv(env).upsert<Self>(Meta, newModel, include);
         }
 
-        export async function get(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Self | null>> {
+        export async function get(env: { db1: Env["db1"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Self | null>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).get<Self>(Meta, args.query, args.include, {});
         }
 
-        export async function list(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<DB1Model.Self[]>> {
+        export async function list(env: { db1: Env["db1"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<DB1Model.Self[]>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).list<Self>(Meta, args.query, args.include);
         }
@@ -68,7 +68,7 @@ export namespace DB1Model {
             return CloesceOrm.map<Self>(Meta, result, Source.Default.include);
         }
 
-        export async function hydrate(env: Env, base: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
+        export async function hydrate(env: { db1: Env["db1"] }, base: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
             return await CloesceOrm.fromEnv(env).hydrate<Self>(Meta, base, {  }, include);
         }
     }
@@ -97,28 +97,28 @@ export namespace DB2Model {
     export namespace Source {
         export const Default = {
             include: {},
-            getQuery: (env: Env, id: number) => env.db2.prepare(`SELECT "DB2Model"."id" AS "id", "DB2Model"."someColumn" AS "someColumn" FROM "DB2Model" WHERE "DB2Model"."id" = ?1`).bind(id),
-            async get(env: Env, id: number): Promise<CloesceResult<DB2Model.Self | null>> {
+            getQuery: (env: { db2: Env["db2"] }, id: number) => env.db2.prepare(`SELECT "DB2Model"."id" AS "id", "DB2Model"."someColumn" AS "someColumn" FROM "DB2Model" WHERE "DB2Model"."id" = ?1`).bind(id),
+            async get(env: { db2: Env["db2"] }, id: number): Promise<CloesceResult<DB2Model.Self | null>> {
                 return await CloesceOrm.fromEnv(env).get<DB2Model.Self>(DB2Model.Meta, DB2Model.Source.Default.getQuery(env, id), DB2Model.Source.Default.include, {  });
             },
-            listQuery: (env: Env, lastSeen_id: number, limit: number) => env.db2.prepare(`SELECT "DB2Model"."id" AS "id", "DB2Model"."someColumn" AS "someColumn" FROM "DB2Model" WHERE "DB2Model"."id" > ?1 ORDER BY "DB2Model"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
-            async list(env: Env, lastSeen_id: number, limit: number): Promise<CloesceResult<DB2Model.Self[]>> {
+            listQuery: (env: { db2: Env["db2"] }, lastSeen_id: number, limit: number) => env.db2.prepare(`SELECT "DB2Model"."id" AS "id", "DB2Model"."someColumn" AS "someColumn" FROM "DB2Model" WHERE "DB2Model"."id" > ?1 ORDER BY "DB2Model"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
+            async list(env: { db2: Env["db2"] }, lastSeen_id: number, limit: number): Promise<CloesceResult<DB2Model.Self[]>> {
                 return await CloesceOrm.fromEnv(env).list<DB2Model.Self>(DB2Model.Meta, DB2Model.Source.Default.listQuery(env, lastSeen_id, limit), DB2Model.Source.Default.include);
             },
         }
     }
 
     export namespace Orm {
-        export async function save(env: Env, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
+        export async function save(env: { db2: Env["db2"] }, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
             return await CloesceOrm.fromEnv(env).upsert<Self>(Meta, newModel, include);
         }
 
-        export async function get(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Self | null>> {
+        export async function get(env: { db2: Env["db2"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Self | null>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).get<Self>(Meta, args.query, args.include, {});
         }
 
-        export async function list(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<DB2Model.Self[]>> {
+        export async function list(env: { db2: Env["db2"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<DB2Model.Self[]>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).list<Self>(Meta, args.query, args.include);
         }
@@ -131,7 +131,7 @@ export namespace DB2Model {
             return CloesceOrm.map<Self>(Meta, result, Source.Default.include);
         }
 
-        export async function hydrate(env: Env, base: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
+        export async function hydrate(env: { db2: Env["db2"] }, base: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
             return await CloesceOrm.fromEnv(env).hydrate<Self>(Meta, base, {  }, include);
         }
     }

--- a/tests/e2e/fixtures/nullability/backend.ts
+++ b/tests/e2e/fixtures/nullability/backend.ts
@@ -24,28 +24,23 @@ export namespace NullabilityChecks {
     }
 
     export interface Api {
-
         primitiveTypes(
             self: NullabilityChecks.Self,
             a: number | null,
             b: string | null,
         ): ApiResult<boolean | null>;
-
         modelTypes(
             self: NullabilityChecks.Self,
             a: NullabilityChecks.Self | null,
         ): ApiResult<NullabilityChecks.Self | null>;
-
         injectableTypes(
             self: NullabilityChecks.Self,
         ): ApiResult<void>;
-
         arrayTypes(
             self: NullabilityChecks.Self,
             a: number[] | null,
             b: NullabilityChecks.Self[] | null,
         ): ApiResult<string[] | null>;
-
         httpResultTypes(
             self: NullabilityChecks.Self,
         ): ApiResult<NullabilityChecks.Self[] | null>;
@@ -59,28 +54,28 @@ export namespace NullabilityChecks {
     export namespace Source {
         export const Default = {
             include: {},
-            getQuery: (env: Env, id: number) => env.db.prepare(`SELECT "NullabilityChecks"."id" AS "id", "NullabilityChecks"."notNullableString" AS "notNullableString", "NullabilityChecks"."nullableString" AS "nullableString" FROM "NullabilityChecks" WHERE "NullabilityChecks"."id" = ?1`).bind(id),
-            async get(env: Env, id: number): Promise<CloesceResult<NullabilityChecks.Self | null>> {
+            getQuery: (env: { db: Env["db"] }, id: number) => env.db.prepare(`SELECT "NullabilityChecks"."id" AS "id", "NullabilityChecks"."notNullableString" AS "notNullableString", "NullabilityChecks"."nullableString" AS "nullableString" FROM "NullabilityChecks" WHERE "NullabilityChecks"."id" = ?1`).bind(id),
+            async get(env: { db: Env["db"] }, id: number): Promise<CloesceResult<NullabilityChecks.Self | null>> {
                 return await CloesceOrm.fromEnv(env).get<NullabilityChecks.Self>(NullabilityChecks.Meta, NullabilityChecks.Source.Default.getQuery(env, id), NullabilityChecks.Source.Default.include, {  });
             },
-            listQuery: (env: Env, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "NullabilityChecks"."id" AS "id", "NullabilityChecks"."notNullableString" AS "notNullableString", "NullabilityChecks"."nullableString" AS "nullableString" FROM "NullabilityChecks" WHERE "NullabilityChecks"."id" > ?1 ORDER BY "NullabilityChecks"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
-            async list(env: Env, lastSeen_id: number, limit: number): Promise<CloesceResult<NullabilityChecks.Self[]>> {
+            listQuery: (env: { db: Env["db"] }, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "NullabilityChecks"."id" AS "id", "NullabilityChecks"."notNullableString" AS "notNullableString", "NullabilityChecks"."nullableString" AS "nullableString" FROM "NullabilityChecks" WHERE "NullabilityChecks"."id" > ?1 ORDER BY "NullabilityChecks"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
+            async list(env: { db: Env["db"] }, lastSeen_id: number, limit: number): Promise<CloesceResult<NullabilityChecks.Self[]>> {
                 return await CloesceOrm.fromEnv(env).list<NullabilityChecks.Self>(NullabilityChecks.Meta, NullabilityChecks.Source.Default.listQuery(env, lastSeen_id, limit), NullabilityChecks.Source.Default.include);
             },
         }
     }
 
     export namespace Orm {
-        export async function save(env: Env, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
+        export async function save(env: { db: Env["db"] }, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
             return await CloesceOrm.fromEnv(env).upsert<Self>(Meta, newModel, include);
         }
 
-        export async function get(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Self | null>> {
+        export async function get(env: { db: Env["db"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Self | null>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).get<Self>(Meta, args.query, args.include, {});
         }
 
-        export async function list(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<NullabilityChecks.Self[]>> {
+        export async function list(env: { db: Env["db"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<NullabilityChecks.Self[]>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).list<Self>(Meta, args.query, args.include);
         }
@@ -93,7 +88,7 @@ export namespace NullabilityChecks {
             return CloesceOrm.map<Self>(Meta, result, Source.Default.include);
         }
 
-        export async function hydrate(env: Env, base: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
+        export async function hydrate(env: { db: Env["db"] }, base: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
             return await CloesceOrm.fromEnv(env).hydrate<Self>(Meta, base, {  }, include);
         }
     }

--- a/tests/e2e/fixtures/partials/backend.ts
+++ b/tests/e2e/fixtures/partials/backend.ts
@@ -24,14 +24,12 @@ export namespace Dog {
     }
 
     export interface Api {
-
         create(
             env: {
                 db: Env["db"],
             },
             dog: DeepPartial<Dog.Self>,
         ): ApiResult<Dog.Self>;
-
         getPartialSelf(
             self: Dog.Self,
         ): ApiResult<DeepPartial<Dog.Self>>;
@@ -45,28 +43,28 @@ export namespace Dog {
     export namespace Source {
         export const Default = {
             include: {},
-            getQuery: (env: Env, id: number) => env.db.prepare(`SELECT "Dog"."id" AS "id", "Dog"."name" AS "name", "Dog"."age" AS "age" FROM "Dog" WHERE "Dog"."id" = ?1`).bind(id),
-            async get(env: Env, id: number): Promise<CloesceResult<Dog.Self | null>> {
+            getQuery: (env: { db: Env["db"] }, id: number) => env.db.prepare(`SELECT "Dog"."id" AS "id", "Dog"."name" AS "name", "Dog"."age" AS "age" FROM "Dog" WHERE "Dog"."id" = ?1`).bind(id),
+            async get(env: { db: Env["db"] }, id: number): Promise<CloesceResult<Dog.Self | null>> {
                 return await CloesceOrm.fromEnv(env).get<Dog.Self>(Dog.Meta, Dog.Source.Default.getQuery(env, id), Dog.Source.Default.include, {  });
             },
-            listQuery: (env: Env, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "Dog"."id" AS "id", "Dog"."name" AS "name", "Dog"."age" AS "age" FROM "Dog" WHERE "Dog"."id" > ?1 ORDER BY "Dog"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
-            async list(env: Env, lastSeen_id: number, limit: number): Promise<CloesceResult<Dog.Self[]>> {
+            listQuery: (env: { db: Env["db"] }, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "Dog"."id" AS "id", "Dog"."name" AS "name", "Dog"."age" AS "age" FROM "Dog" WHERE "Dog"."id" > ?1 ORDER BY "Dog"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
+            async list(env: { db: Env["db"] }, lastSeen_id: number, limit: number): Promise<CloesceResult<Dog.Self[]>> {
                 return await CloesceOrm.fromEnv(env).list<Dog.Self>(Dog.Meta, Dog.Source.Default.listQuery(env, lastSeen_id, limit), Dog.Source.Default.include);
             },
         }
     }
 
     export namespace Orm {
-        export async function save(env: Env, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
+        export async function save(env: { db: Env["db"] }, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
             return await CloesceOrm.fromEnv(env).upsert<Self>(Meta, newModel, include);
         }
 
-        export async function get(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Self | null>> {
+        export async function get(env: { db: Env["db"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Self | null>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).get<Self>(Meta, args.query, args.include, {});
         }
 
-        export async function list(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Dog.Self[]>> {
+        export async function list(env: { db: Env["db"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Dog.Self[]>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).list<Self>(Meta, args.query, args.include);
         }
@@ -79,7 +77,7 @@ export namespace Dog {
             return CloesceOrm.map<Self>(Meta, result, Source.Default.include);
         }
 
-        export async function hydrate(env: Env, base: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
+        export async function hydrate(env: { db: Env["db"] }, base: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
             return await CloesceOrm.fromEnv(env).hydrate<Self>(Meta, base, {  }, include);
         }
     }

--- a/tests/e2e/fixtures/poos/backend.ts
+++ b/tests/e2e/fixtures/poos/backend.ts
@@ -33,13 +33,11 @@ export namespace PooAcceptYield {
     }
 
     export interface Api {
-
         acceptPoos(
             a: PooA,
             b: PooB,
             c: PooC,
         ): ApiResult<void>;
-
         yieldPoo(
         ): ApiResult<PooC>;
     }
@@ -52,28 +50,28 @@ export namespace PooAcceptYield {
     export namespace Source {
         export const Default = {
             include: {},
-            getQuery: (env: Env, id: number) => env.db.prepare(`SELECT "PooAcceptYield"."id" AS "id" FROM "PooAcceptYield" WHERE "PooAcceptYield"."id" = ?1`).bind(id),
-            async get(env: Env, id: number): Promise<CloesceResult<PooAcceptYield.Self | null>> {
+            getQuery: (env: { db: Env["db"] }, id: number) => env.db.prepare(`SELECT "PooAcceptYield"."id" AS "id" FROM "PooAcceptYield" WHERE "PooAcceptYield"."id" = ?1`).bind(id),
+            async get(env: { db: Env["db"] }, id: number): Promise<CloesceResult<PooAcceptYield.Self | null>> {
                 return await CloesceOrm.fromEnv(env).get<PooAcceptYield.Self>(PooAcceptYield.Meta, PooAcceptYield.Source.Default.getQuery(env, id), PooAcceptYield.Source.Default.include, {  });
             },
-            listQuery: (env: Env, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "PooAcceptYield"."id" AS "id" FROM "PooAcceptYield" WHERE "PooAcceptYield"."id" > ?1 ORDER BY "PooAcceptYield"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
-            async list(env: Env, lastSeen_id: number, limit: number): Promise<CloesceResult<PooAcceptYield.Self[]>> {
+            listQuery: (env: { db: Env["db"] }, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "PooAcceptYield"."id" AS "id" FROM "PooAcceptYield" WHERE "PooAcceptYield"."id" > ?1 ORDER BY "PooAcceptYield"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
+            async list(env: { db: Env["db"] }, lastSeen_id: number, limit: number): Promise<CloesceResult<PooAcceptYield.Self[]>> {
                 return await CloesceOrm.fromEnv(env).list<PooAcceptYield.Self>(PooAcceptYield.Meta, PooAcceptYield.Source.Default.listQuery(env, lastSeen_id, limit), PooAcceptYield.Source.Default.include);
             },
         }
     }
 
     export namespace Orm {
-        export async function save(env: Env, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
+        export async function save(env: { db: Env["db"] }, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
             return await CloesceOrm.fromEnv(env).upsert<Self>(Meta, newModel, include);
         }
 
-        export async function get(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Self | null>> {
+        export async function get(env: { db: Env["db"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Self | null>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).get<Self>(Meta, args.query, args.include, {});
         }
 
-        export async function list(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<PooAcceptYield.Self[]>> {
+        export async function list(env: { db: Env["db"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<PooAcceptYield.Self[]>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).list<Self>(Meta, args.query, args.include);
         }
@@ -86,7 +84,7 @@ export namespace PooAcceptYield {
             return CloesceOrm.map<Self>(Meta, result, Source.Default.include);
         }
 
-        export async function hydrate(env: Env, base: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
+        export async function hydrate(env: { db: Env["db"] }, base: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
             return await CloesceOrm.fromEnv(env).hydrate<Self>(Meta, base, {  }, include);
         }
     }

--- a/tests/e2e/fixtures/r2/backend.ts
+++ b/tests/e2e/fixtures/r2/backend.ts
@@ -31,7 +31,6 @@ export namespace D1BackedModel {
     }
 
     export interface Api {
-
         uploadData(
             self: D1BackedModel.Self,
             env: {
@@ -49,28 +48,28 @@ export namespace D1BackedModel {
     export namespace Source {
         export const Default = {
             include: {"r2Data":{}},
-            getQuery: (env: Env, id: number) => env.db.prepare(`SELECT "D1BackedModel"."id" AS "id", "D1BackedModel"."someColumn" AS "someColumn", "D1BackedModel"."someOtherColumn" AS "someOtherColumn" FROM "D1BackedModel" WHERE "D1BackedModel"."id" = ?1`).bind(id),
-            async get(env: Env, id: number, keyParam: string): Promise<CloesceResult<D1BackedModel.Self | null>> {
+            getQuery: (env: { bucket1: Env["bucket1"], db: Env["db"] }, id: number) => env.db.prepare(`SELECT "D1BackedModel"."id" AS "id", "D1BackedModel"."someColumn" AS "someColumn", "D1BackedModel"."someOtherColumn" AS "someOtherColumn" FROM "D1BackedModel" WHERE "D1BackedModel"."id" = ?1`).bind(id),
+            async get(env: { bucket1: Env["bucket1"], db: Env["db"] }, id: number, keyParam: string): Promise<CloesceResult<D1BackedModel.Self | null>> {
                 return await CloesceOrm.fromEnv(env).get<D1BackedModel.Self>(D1BackedModel.Meta, D1BackedModel.Source.Default.getQuery(env, id), D1BackedModel.Source.Default.include, { keyParam });
             },
-            listQuery: (env: Env, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "D1BackedModel"."id" AS "id", "D1BackedModel"."someColumn" AS "someColumn", "D1BackedModel"."someOtherColumn" AS "someOtherColumn" FROM "D1BackedModel" WHERE "D1BackedModel"."id" > ?1 ORDER BY "D1BackedModel"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
-            async list(env: Env, lastSeen_id: number, limit: number): Promise<CloesceResult<D1BackedModel.Self[]>> {
+            listQuery: (env: { bucket1: Env["bucket1"], db: Env["db"] }, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "D1BackedModel"."id" AS "id", "D1BackedModel"."someColumn" AS "someColumn", "D1BackedModel"."someOtherColumn" AS "someOtherColumn" FROM "D1BackedModel" WHERE "D1BackedModel"."id" > ?1 ORDER BY "D1BackedModel"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
+            async list(env: { bucket1: Env["bucket1"], db: Env["db"] }, lastSeen_id: number, limit: number): Promise<CloesceResult<D1BackedModel.Self[]>> {
                 return await CloesceOrm.fromEnv(env).list<D1BackedModel.Self>(D1BackedModel.Meta, D1BackedModel.Source.Default.listQuery(env, lastSeen_id, limit), D1BackedModel.Source.Default.include);
             },
         }
     }
 
     export namespace Orm {
-        export async function save(env: Env, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
+        export async function save(env: { bucket1: Env["bucket1"], db: Env["db"] }, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
             return await CloesceOrm.fromEnv(env).upsert<Self>(Meta, newModel, include);
         }
 
-        export async function get(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self>, keyFields?: { keyParam?: string } }): Promise<CloesceResult<Self | null>> {
+        export async function get(env: { bucket1: Env["bucket1"], db: Env["db"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self>, keyFields?: { keyParam?: string } }): Promise<CloesceResult<Self | null>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).get<Self>(Meta, args.query, args.include, args.keyFields ?? {});
         }
 
-        export async function list(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<D1BackedModel.Self[]>> {
+        export async function list(env: { bucket1: Env["bucket1"], db: Env["db"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<D1BackedModel.Self[]>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).list<Self>(Meta, args.query, args.include);
         }
@@ -83,7 +82,7 @@ export namespace D1BackedModel {
             return CloesceOrm.map<Self>(Meta, result, Source.Default.include);
         }
 
-        export async function hydrate(env: Env, base: DeepPartial<Self>, keyParam: string, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
+        export async function hydrate(env: { bucket1: Env["bucket1"], db: Env["db"] }, base: DeepPartial<Self>, keyParam: string, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
             return await CloesceOrm.fromEnv(env).hydrate<Self>(Meta, base, { keyParam }, include);
         }
     }
@@ -113,7 +112,6 @@ export namespace PureR2Model {
     }
 
     export interface Api {
-
         uploadData(
             self: PureR2Model.Self,
             env: {
@@ -121,7 +119,6 @@ export namespace PureR2Model {
             },
             data: CfReadableStream,
         ): ApiResult<void>;
-
         uploadOtherData(
             self: PureR2Model.Self,
             env: {
@@ -139,23 +136,23 @@ export namespace PureR2Model {
     export namespace Source {
         export const Default = {
             include: {"allData":{},"data":{},"otherData":{}},
-            async get(env: Env, id: string): Promise<PureR2Model.Self | null> {
+            async get(env: { bucket1: Env["bucket1"] }, id: string): Promise<PureR2Model.Self | null> {
                 return await CloesceOrm.fromEnv(env).get<PureR2Model.Self>(PureR2Model.Meta, null, PureR2Model.Source.Default.include, { id });
             },
         }
     }
 
     export namespace Orm {
-        export async function save(env: Env, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
+        export async function save(env: { bucket1: Env["bucket1"] }, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
             return await CloesceOrm.fromEnv(env).upsert<Self>(Meta, newModel, include);
         }
 
-        export async function get(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self>, keyFields?: { id?: string } }): Promise<CloesceResult<Self | null>> {
+        export async function get(env: { bucket1: Env["bucket1"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self>, keyFields?: { id?: string } }): Promise<CloesceResult<Self | null>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).get<Self>(Meta, args.query, args.include, args.keyFields ?? {});
         }
 
-        export async function list(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<PureR2Model.Self[]>> {
+        export async function list(env: { bucket1: Env["bucket1"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<PureR2Model.Self[]>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).list<Self>(Meta, args.query, args.include);
         }
@@ -168,7 +165,7 @@ export namespace PureR2Model {
             return CloesceOrm.map<Self>(Meta, result, Source.Default.include);
         }
 
-        export async function hydrate(env: Env, base: DeepPartial<Self>, id: string, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
+        export async function hydrate(env: { bucket1: Env["bucket1"] }, base: DeepPartial<Self>, id: string, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
             return await CloesceOrm.fromEnv(env).hydrate<Self>(Meta, base, { id }, include);
         }
     }

--- a/tests/e2e/fixtures/services/backend.ts
+++ b/tests/e2e/fixtures/services/backend.ts
@@ -15,7 +15,6 @@ export namespace FooService {
     export const Tag = "FooService" as const;
 
     export interface Api {
-
         method(
             env: {
                 InjectedThing: InjectedThing,

--- a/tests/e2e/fixtures/validators/backend.ts
+++ b/tests/e2e/fixtures/validators/backend.ts
@@ -29,7 +29,6 @@ export namespace Validator {
     }
 
     export interface Api {
-
         someMethod(
             self: Validator.Self,
             id: number,
@@ -45,39 +44,39 @@ export namespace Validator {
     export namespace Source {
         export const Default = {
             include: {"data":{}},
-            getQuery: (env: Env, id: number) => env.db.prepare(`SELECT "Validator"."id" AS "id", "Validator"."email" AS "email" FROM "Validator" WHERE "Validator"."id" = ?1`).bind(id),
-            async get(env: Env, id: number, name: string): Promise<CloesceResult<Validator.Self | null>> {
+            getQuery: (env: { db: Env["db"], store: Env["store"] }, id: number) => env.db.prepare(`SELECT "Validator"."id" AS "id", "Validator"."email" AS "email" FROM "Validator" WHERE "Validator"."id" = ?1`).bind(id),
+            async get(env: { db: Env["db"], store: Env["store"] }, id: number, name: string): Promise<CloesceResult<Validator.Self | null>> {
                 return await CloesceOrm.fromEnv(env).get<Validator.Self>(Validator.Meta, Validator.Source.Default.getQuery(env, id), Validator.Source.Default.include, { name });
             },
-            listQuery: (env: Env, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "Validator"."id" AS "id", "Validator"."email" AS "email" FROM "Validator" WHERE "Validator"."id" > ?1 ORDER BY "Validator"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
-            async list(env: Env, lastSeen_id: number, limit: number): Promise<CloesceResult<Validator.Self[]>> {
+            listQuery: (env: { db: Env["db"], store: Env["store"] }, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "Validator"."id" AS "id", "Validator"."email" AS "email" FROM "Validator" WHERE "Validator"."id" > ?1 ORDER BY "Validator"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
+            async list(env: { db: Env["db"], store: Env["store"] }, lastSeen_id: number, limit: number): Promise<CloesceResult<Validator.Self[]>> {
                 return await CloesceOrm.fromEnv(env).list<Validator.Self>(Validator.Meta, Validator.Source.Default.listQuery(env, lastSeen_id, limit), Validator.Source.Default.include);
             },
         }
         export const None = {
             include: {},
-            getQuery: (env: Env, id: number) => env.db.prepare(`SELECT "Validator"."id" AS "id", "Validator"."email" AS "email" FROM "Validator" WHERE "Validator"."id" = ?1`).bind(id),
-            async get(env: Env, id: number, name: string): Promise<CloesceResult<Validator.Self | null>> {
+            getQuery: (env: { db: Env["db"] }, id: number) => env.db.prepare(`SELECT "Validator"."id" AS "id", "Validator"."email" AS "email" FROM "Validator" WHERE "Validator"."id" = ?1`).bind(id),
+            async get(env: { db: Env["db"] }, id: number, name: string): Promise<CloesceResult<Validator.Self | null>> {
                 return await CloesceOrm.fromEnv(env).get<Validator.Self>(Validator.Meta, Validator.Source.None.getQuery(env, id), Validator.Source.None.include, { name });
             },
-            listQuery: (env: Env, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "Validator"."id" AS "id", "Validator"."email" AS "email" FROM "Validator" WHERE "Validator"."id" > ?1 ORDER BY "Validator"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
-            async list(env: Env, lastSeen_id: number, limit: number): Promise<CloesceResult<Validator.Self[]>> {
+            listQuery: (env: { db: Env["db"] }, lastSeen_id: number, limit: number) => env.db.prepare(`SELECT "Validator"."id" AS "id", "Validator"."email" AS "email" FROM "Validator" WHERE "Validator"."id" > ?1 ORDER BY "Validator"."id" ASC LIMIT ?2`).bind(lastSeen_id, limit),
+            async list(env: { db: Env["db"] }, lastSeen_id: number, limit: number): Promise<CloesceResult<Validator.Self[]>> {
                 return await CloesceOrm.fromEnv(env).list<Validator.Self>(Validator.Meta, Validator.Source.None.listQuery(env, lastSeen_id, limit), Validator.Source.None.include);
             },
         }
     }
 
     export namespace Orm {
-        export async function save(env: Env, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
+        export async function save(env: { db: Env["db"], store: Env["store"] }, newModel: DeepPartial<Self>, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self | null>> {
             return await CloesceOrm.fromEnv(env).upsert<Self>(Meta, newModel, include);
         }
 
-        export async function get(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self>, keyFields?: { name?: string } }): Promise<CloesceResult<Self | null>> {
+        export async function get(env: { db: Env["db"], store: Env["store"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self>, keyFields?: { name?: string } }): Promise<CloesceResult<Self | null>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).get<Self>(Meta, args.query, args.include, args.keyFields ?? {});
         }
 
-        export async function list(env: Env, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Validator.Self[]>> {
+        export async function list(env: { db: Env["db"], store: Env["store"] }, args: { query?: D1PreparedStatement, include?: IncludeTree<Self> }): Promise<CloesceResult<Validator.Self[]>> {
             args.include ??= Source.Default.include;
             return await CloesceOrm.fromEnv(env).list<Self>(Meta, args.query, args.include);
         }
@@ -90,7 +89,7 @@ export namespace Validator {
             return CloesceOrm.map<Self>(Meta, result, Source.Default.include);
         }
 
-        export async function hydrate(env: Env, base: DeepPartial<Self>, name: string, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
+        export async function hydrate(env: { db: Env["db"], store: Env["store"] }, base: DeepPartial<Self>, name: string, include: IncludeTree<Self> = Source.Default.include): Promise<CloesceResult<Self>> {
             return await CloesceOrm.fromEnv(env).hydrate<Self>(Meta, base, { name }, include);
         }
     }


### PR DESCRIPTION
After explicit dependency injection was introduced, ORM methods still required the full `Env` to be passed. This PR changes the generator to find the minimum subset of bindings for each Data Source and ORM methods.