### PR TITLE
opt: reduce ORM WASM size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# [0.5.2] - Unreleased
+# [0.5.2] - 6/21/2026
 
 ### Added
 
@@ -6,9 +6,11 @@
 
 ### Changed
 
+- Modified ORM code to reduce the WASM binary by 1.3MB
+
 ### Fixed
 
-# [0.5.1] - 2026-6-19
+# [0.5.1] - 6/19/2026
 
 ### Added
 
@@ -25,7 +27,7 @@
 - Extra Durable Object injects would be added to an API method if it used a DO's KV templates
 - Errors would sometimes return `{}` instead of enumerating the error fields due to a bug in the error serialization logic.
 
-# [0.5.0] - 2026-06-18
+# [0.5.0] - 6/18/2026
 
 ### Added
 
@@ -57,7 +59,7 @@
 
 - A bug with `date` serialization and deserialization using improper ISO strings
 
-# [0.4.1] - 2026-5-20
+# [0.4.1] - 5/20/2026
 
 ### Added
 
@@ -70,7 +72,7 @@
 
 ### Fixed
 
-# [0.4.0] - 2026-5-19
+# [0.4.0] - 5/19/2026
 
 ### Added
 
@@ -98,7 +100,7 @@
 
 ### Fixed
 
-# [0.3.9] - 2026-4-19
+# [0.3.9] - 4/19/2026
 
 ### Added
 
@@ -108,7 +110,7 @@
 
 - A bug where the `impl` function would widen the return type to `ApiResult` instead of inferring the specific return type of the method, making it difficult to work with the results without manually type asserting.
 
-# [0.3.8] - 2026-4-17
+# [0.3.8] - 4/17/2026
 
 ### Added
 
@@ -119,7 +121,7 @@
 
 ### Fixed
 
-# [0.3.7] - 2026-4-17
+# [0.3.7] - 4/17/2026
 
 ### Added
 
@@ -130,7 +132,7 @@
 - Misc bugs in `cloesce fmt`
 - `"Default"` was not correctly overriding on client crud methods, making users manually specify it.
 
-# [0.3.6] - 2026-4-15
+# [0.3.6] - 4/15/2026
 
 ### Added
 
@@ -142,7 +144,7 @@
 
 ### Fixed
 
-# [0.3.5] - 2026-4-9
+# [0.3.5] - 4/9/2026
 
 ### Added
 
@@ -153,7 +155,7 @@
 
 ### Fixed
 
-# [0.3.4] - 2026-4-8
+# [0.3.4] - 4/8/2026
 
 ### Added
 
@@ -166,7 +168,7 @@
 
 - GitHub API rate limit issues
 
-# [0.3.3] - 2026-4-8
+# [0.3.3] - 4/8/2026
 
 ### Added
 
@@ -183,7 +185,7 @@
 - Miscellaneous bug fixes in the CLI
 - Timestamp name bug in the migrations CLI
 
-# [0.3.2] - 2026-4-6
+# [0.3.2] - 4/6/2026
 
 ### Added
 
@@ -199,7 +201,7 @@
 
 ### Fixed
 
-# [0.3.1] - 2026-4-6
+# [0.3.1] - 4/6/2026
 
 ### Added
 
@@ -209,7 +211,7 @@
 
 - A bug where Windows could not run migrations due to file path issues.
 
-# [0.3.0] - 2026-4-6
+# [0.3.0] - 4/6/2026
 
 ### Added
 
@@ -222,7 +224,7 @@
 
 ### Fixed
 
-# [0.2.3] - 2026-3-24
+# [0.2.3] - 3/24/2026
 
 ### Added
 
@@ -232,7 +234,7 @@
 
 - Fixed Windows compilation issues.
 
-# [0.2.2] - 2026-3-14
+# [0.2.2] - 3/14/2026
 
 ### Added
 
@@ -243,7 +245,7 @@
 
 ### Fixed
 
-# [0.2.0] - 2026-03-14
+# [0.2.0] - 3/14/2026
 
 ### Added
 
@@ -267,7 +269,7 @@
 
 ### Fixed
 
-# [0.1.5] - 2026-2-20
+# [0.1.5] - 2/20/2026
 
 ### Added
 
@@ -277,7 +279,7 @@
 
 - A bug where `upsert` would not properly replace an undefined value with `null` when the column is nullable.
 
-# [0.1.3] - 2026-2-12
+# [0.1.3] - 2/12/2026
 
 ### Added
 
@@ -288,7 +290,7 @@
 - A single missing value from the wrangler `d1_databases` would crash the generator
 - `wrangler` tests were not being ran in CI/CD because of misnamed test folder
 
-# [0.1.2] - 2026-2-3
+# [0.1.2] - 2/3/2026
 
 ### Added
 
@@ -299,7 +301,7 @@
 - boolean data types in the `upsert` expected integers
 - boolean data types after `hydrate` should be booleans, not integers
 
-# [0.1.1] - 2026-2-3
+# [0.1.1] - 2/3/2026
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,16 +227,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
-name = "chrono"
-version = "0.4.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
-dependencies = [
- "num-traits",
- "serde",
-]
-
-[[package]]
 name = "chumsky"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1214,13 +1204,11 @@ name = "orm"
 version = "0.0.0"
 dependencies = [
  "base64",
- "chrono",
  "compiler-test",
  "frontend",
  "idl",
- "indexmap",
  "migrations",
- "regex",
+ "regex-lite",
  "sea-query",
  "serde",
  "serde_json",
@@ -1432,18 +1420,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata 0.4.14",
- "regex-syntax 0.8.10",
-]
-
-[[package]]
 name = "regex-automata"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1464,6 +1440,12 @@ dependencies = [
  "memchr",
  "regex-syntax 0.8.10",
 ]
+
+[[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
 
 [[package]]
 name = "regex-syntax"
@@ -1562,7 +1544,7 @@ dependencies = [
  "idl",
  "indexmap",
  "orm",
- "regex",
+ "regex-lite",
  "sqlx",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ clap = { version = "4.6.1", features = ["derive"] }
 indexmap = { version = "2.14.0", features = ["serde"] }
 insta = "1.46.3"
 json_comments = "0.2.2"
-regex = "1.12.3"
+regex-lite = "0.1.9"
 sea-query = "0.32.7"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.149"
@@ -30,3 +30,13 @@ tracing-subscriber = "0.3.22"
 [profile.dev]
 opt-level = 0
 debug = true
+
+# Size-optimized profile for the orm WASM module.
+# TOOD: Consider `opt-level = "z"`, maybe worth benchmarking some day.
+[profile.wasm-release]
+inherits = "release"
+opt-level = 3
+lto = true
+codegen-units = 1
+panic = "abort"
+strip = "debuginfo"

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ build-src:
 
 	@echo "CLOESCE: Building Rust and TypeScript code..."
 	cargo build --release --manifest-path $(CARGO_MANIFEST) --bin cloesce
-	cargo build --target $(WASM_TARGET) --release --manifest-path $(COMPILER_DIR)/orm/Cargo.toml
+	cargo build --target $(WASM_TARGET) --profile wasm-release --manifest-path $(COMPILER_DIR)/orm/Cargo.toml
 
 	pnpm --filter cloesce run build
 

--- a/proposals/proposal-1-data-sources.md
+++ b/proposals/proposal-1-data-sources.md
@@ -2,8 +2,8 @@
 
 - **Author(s):** Ben Schreiber
 - **Status:** Draft | Review | Accepted | Rejected | **Implemented**
-- **Created:** 2026-02-19
-- **Last Updated:** 2026-02-21
+- **Created:** 2/19/2026
+- **Last Updated:** 2/21/2026
 
 ---
 

--- a/proposals/proposal-2-analyzer-and-pagination.md
+++ b/proposals/proposal-2-analyzer-and-pagination.md
@@ -2,8 +2,8 @@
 
 - **Author(s):** Ben Schreiber
 - **Status:** Draft | Review | Accepted | Rejected | **Implemented**
-- **Created:** 2026-02-26
-- **Last Updated:** 2026-02-26
+- **Created:** 2/26/2026
+- **Last Updated:** 2/26/2026
 
 ---
 

--- a/proposals/proposal-3-composite-keys-unique.md
+++ b/proposals/proposal-3-composite-keys-unique.md
@@ -2,8 +2,8 @@
 
 - **Author(s):** Ben Schreiber
 - **Status:** Draft | Review | Accepted | Rejected | **Implemented**
-- **Created:** 2026-02-26
-- **Last Updated:** 2026-02-26
+- **Created:** 2/26/2026
+- **Last Updated:** 2/26/2026
 
 ---
 

--- a/proposals/proposal-4-cloesce-lang.md
+++ b/proposals/proposal-4-cloesce-lang.md
@@ -5,8 +5,8 @@
 
 - **Author(s):** Ben Schreiber
 - **Status:** Draft | Review | Accepted | Rejected | **Implemented**
-- **Created:** 2026-04-06
-- **Last Updated:** 2026-04-06
+- **Created:** 4/6/2026
+- **Last Updated:** 4/6/2026
 
 ---
 

--- a/proposals/proposal-5-validator-tags.md
+++ b/proposals/proposal-5-validator-tags.md
@@ -2,8 +2,8 @@
 
 - **Author(s):** Ben Schreiber
 - **Status:** Draft | Review | Accepted | Rejected | **Implemented**
-- **Created:** 2026-04-21
-- **Last Updated:** 2026-05-06
+- **Created:** 4/21/2026
+- **Last Updated:** 5/6/2026
 
 ---
 

--- a/proposals/proposal-6-binding-templates.md
+++ b/proposals/proposal-6-binding-templates.md
@@ -2,8 +2,8 @@
 
 - **Author(s):** Ben Schreiber
 - **Status:** Draft | Review | Accepted | Rejected | **Implemented**
-- **Created:** 2026-05-13
-- **Last Updated:** 2026-06-03
+- **Created:** 5/13/2026
+- **Last Updated:** 6/3/2026
 
 ---
 

--- a/proposals/proposal-7-durable-objects.md
+++ b/proposals/proposal-7-durable-objects.md
@@ -2,8 +2,8 @@
 
 - **Author(s):** Ben Schreiber
 - **Status:** Draft | Review | Accepted | Rejected | **Implemented**
-- **Created:** 2026-04-30
-- **Last Updated:** 2026-06-14
+- **Created:** 4/30/2026
+- **Last Updated:** 6/14/2026
 
 ---
 

--- a/proposals/template.md
+++ b/proposals/template.md
@@ -6,8 +6,8 @@ Below is a template for writing a proposal for changes to Cloesce. Any significa
 
 - **Author(s):** <Name(s)>
 - **Status:** Draft | Review | Accepted | Rejected | Implemented
-- **Created:** YYYY-MM-DD
-- **Last Updated:** YYYY-MM-DD
+- **Created:** M/D/YYYY
+- **Last Updated:** M/D/YYYY
 
 ---
 

--- a/src/compiler/orm/Cargo.toml
+++ b/src/compiler/orm/Cargo.toml
@@ -5,14 +5,11 @@ edition = "2024"
 [dependencies]
 idl = { path = "../idl" }
 base64 = "0.22"
-chrono = { version = "0.4.44", features = ["serde"], default-features = false }
 frontend = { path = "../frontend" }
-indexmap = { workspace = true }
-regex = { workspace = true }
+regex-lite = { workspace = true }
 sea-query = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-
 
 [dev-dependencies]
 compiler-test = { path = "../compiler-test" }

--- a/src/compiler/orm/src/map.rs
+++ b/src/compiler/orm/src/map.rs
@@ -1,7 +1,8 @@
+use std::collections::HashMap;
+
 use idl::CloesceIdl;
 use idl::Model;
 use idl::NavigationFieldKind;
-use indexmap::IndexMap;
 use serde_json::Map;
 use serde_json::Value;
 
@@ -30,7 +31,7 @@ pub fn map_sql(
         return Ok(vec![]);
     }
 
-    let mut result_map = IndexMap::new();
+    let mut result_map = HashMap::new();
 
     // Scan each row for the root model (`model_name`)'s primary key
     for row in rows.iter() {
@@ -61,8 +62,8 @@ pub fn map_sql(
             let mut m = serde_json::Map::new();
 
             // Set primary key columns
-            for (name, value) in &pk_values {
-                m.insert(name.clone(), value.clone());
+            for (name, value) in pk_values {
+                m.insert(name, value);
             }
 
             // Set scalar columns
@@ -124,18 +125,23 @@ fn process_navigation_properties(
             continue;
         }
 
-        // Nested properties always use their navigation path prefix (e.g. "cat.toy.id")
+        // Nested properties always use their navigation path prefix (e.g. "cat.toy.id").
+        let mut prefixed_key = if prefix.is_empty() {
+            nav_prop.field.name.to_string()
+        } else {
+            format!("{}.{}", prefix, nav_prop.field.name)
+        };
+        prefixed_key.push('.');
+        let base_len = prefixed_key.len();
+
         // Check all primary key columns for the nested model
         let mut nested_pk_values = Vec::new();
         let mut all_nested_pks_present = true;
 
         for pk in &nested_model.primary_columns {
             let nested_pk_name = &pk.field.name;
-            let prefixed_key = if prefix.is_empty() {
-                format!("{}.{}", nav_prop.field.name, nested_pk_name)
-            } else {
-                format!("{}.{}.{}", prefix, nav_prop.field.name, nested_pk_name)
-            };
+            prefixed_key.truncate(base_len);
+            prefixed_key.push_str(nested_pk_name);
 
             if let Some(nested_pk_value) = row.get(&prefixed_key) {
                 if nested_pk_value.is_null() {
@@ -162,11 +168,8 @@ fn process_navigation_properties(
         // Set nested scalar columns
         for col in &nested_model.columns {
             let name = &col.field.name;
-            let prefixed_key = if prefix.is_empty() {
-                format!("{}.{}", nav_prop.field.name, name)
-            } else {
-                format!("{}.{}.{}", prefix, nav_prop.field.name, name)
-            };
+            prefixed_key.truncate(base_len);
+            prefixed_key.push_str(name);
             let val = row.get(&prefixed_key).cloned();
 
             if let Some(v) = val {

--- a/src/compiler/orm/src/map.rs
+++ b/src/compiler/orm/src/map.rs
@@ -31,7 +31,10 @@ pub fn map_sql(
         return Ok(vec![]);
     }
 
-    let mut result_map = HashMap::new();
+    // Result must come back in the order that it was returned
+    // by the SQL query.
+    let mut result_index = HashMap::<Value, usize>::new();
+    let mut results = Vec::<Value>::new();
 
     // Scan each row for the root model (`model_name`)'s primary key
     for row in rows.iter() {
@@ -57,8 +60,8 @@ pub fn map_sql(
         let composite_key = Value::Array(pk_values.iter().map(|(_, v)| v.clone()).collect());
 
         // A particular primary key will only exist once. If that key does not yet
-        // exist, put a new model into the result map.
-        let model_json = result_map.entry(composite_key).or_insert_with(|| {
+        // exist, put a new model into the results vec.
+        let idx = *result_index.entry(composite_key).or_insert_with(|| {
             let mut m = serde_json::Map::new();
 
             // Set primary key columns
@@ -82,7 +85,8 @@ pub fn map_sql(
                 }
             }
 
-            serde_json::Value::Object(m)
+            results.push(serde_json::Value::Object(m));
+            results.len() - 1
         });
 
         // Given some include tree, we can traverse navigation properties, adding only those that
@@ -91,12 +95,12 @@ pub fn map_sql(
             continue;
         };
 
-        if let Value::Object(model_json) = model_json {
+        if let Value::Object(model_json) = &mut results[idx] {
             process_navigation_properties(model_json, model, "", tree, row, idl)?;
         }
     }
 
-    Ok(result_map.into_values().collect())
+    Ok(results)
 }
 
 fn process_navigation_properties(

--- a/src/compiler/orm/src/upsert.rs
+++ b/src/compiler/orm/src/upsert.rs
@@ -5,7 +5,7 @@ use idl::{CidlType, CloesceIdl, IncludeTree, Model, NavigationFieldKind, Validat
 use frontend::fmt_cidl_type;
 use sea_query::{Alias, OnConflict, SimpleExpr, SqliteQueryBuilder};
 use sea_query::{Expr, Query};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::Map;
 use serde_json::Value;
 
@@ -91,13 +91,15 @@ impl<'a> UpsertModel<'a> {
         let model = idl.models.get(model_name).expect("Model to exist");
         if model.uses_sqlite() {
             // Final select to return the upserted model
-            let include_tree_json_str = serde_json::to_string(&include_tree).unwrap_or_default();
-            let include_tree_typed: IncludeTree =
-                serde_json::from_str(&include_tree_json_str).unwrap_or_default();
-            let select_query =
+            let select_query = {
+                let include_tree_value = Value::Object(include_tree.clone());
+                let include_tree_typed: IncludeTree =
+                    IncludeTree::deserialize(&include_tree_value).unwrap_or_default();
+
                 SelectModel::query(model_name, None, Some(&include_tree_typed), idl)?
                     .trim_start_matches("SELECT ")
-                    .to_string();
+                    .to_string()
+            };
 
             let mut select = Query::select();
             let mut select_root_model = select.expr(Expr::cust(&select_query));
@@ -115,9 +117,7 @@ impl<'a> UpsertModel<'a> {
                 );
             }
 
-            generator
-                .sql_acc
-                .push(build_sqlite(select_root_model.to_owned()));
+            generator.sql_acc.push(build_sqlite(select_root_model));
             generator.sql_acc.push(SqlStatement {
                 query: VariablesTable::delete_all(),
                 values: vec![],
@@ -255,10 +255,13 @@ impl<'a> UpsertModel<'a> {
             )?;
 
             // Map each key column to the path in the context wheere its value can be found
+            let columns_by_name: HashMap<_, _> = model
+                .all_columns()
+                .map(|(c, _)| (c.field.name.as_ref(), c))
+                .collect();
             for field in fields {
-                let (col, _) = model
-                    .all_columns()
-                    .find(|(c, _)| c.field.name == *field)
+                let col = columns_by_name
+                    .get(field)
                     .expect("key column to exist in model");
 
                 let fk = col
@@ -489,8 +492,7 @@ impl VariablesTable {
                 .into_table(alias(VARIABLES_TABLE_NAME))
                 .columns(vec![alias("path"), alias("primary_key")])
                 .values_panic(vec![Expr::val(path).into(), Expr::cust(&json_expr)])
-                .replace()
-                .to_owned(),
+                .replace(),
         )
     }
 }
@@ -613,7 +615,7 @@ impl<'a> SqlUpsertBuilder<'a> {
                     update_stmt.and_where(Expr::col(alias(pk_field.name.as_ref())).eq(expr));
             }
 
-            return Ok(build_sqlite(update_stmt.to_owned()));
+            return Ok(build_sqlite(update_stmt));
         }
 
         // Build an INSERT
@@ -629,9 +631,10 @@ impl<'a> SqlUpsertBuilder<'a> {
             }
         }
 
-        insert.columns(cols.clone()).values_panic(vals);
         if cols.is_empty() {
             insert.or_default_values();
+        } else {
+            insert.columns(cols).values_panic(vals);
         }
 
         // If the key is fully known and there are non-key columns, conflicting on
@@ -657,7 +660,7 @@ impl<'a> SqlUpsertBuilder<'a> {
             );
         }
 
-        Ok(build_sqlite(insert))
+        Ok(build_sqlite(&insert))
     }
 }
 
@@ -743,7 +746,7 @@ fn sea_query_to_serde(v: sea_query::Value) -> serde_json::Value {
     }
 }
 
-fn build_sqlite<T: sea_query::QueryStatementWriter>(qb: T) -> SqlStatement {
+fn build_sqlite<T: sea_query::QueryStatementWriter>(qb: &T) -> SqlStatement {
     let (query, vs) = qb.build(SqliteQueryBuilder);
     SqlStatement {
         query,

--- a/src/compiler/orm/src/validate.rs
+++ b/src/compiler/orm/src/validate.rs
@@ -4,6 +4,7 @@ use idl::{CidlType, CloesceIdl, Number, ValidatedField, Validator};
 
 use base64::{Engine, prelude::BASE64_STANDARD};
 use frontend::fmt_cidl_type;
+use serde::Deserialize;
 use serde_json::Value;
 
 use crate::{OrmErrorKind, fail};
@@ -100,10 +101,7 @@ pub fn validate_cidl_type(
         },
 
         CidlType::DateIso => {
-            let valid = value
-                .as_str()
-                .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
-                .is_some();
+            let valid = value.as_str().is_some_and(is_valid_rfc3339);
             if valid {
                 Some(value)
             } else {
@@ -138,13 +136,13 @@ pub fn validate_cidl_type(
                 size: i64,
                 etag: String,
                 http_etag: String,
-                uploaded: chrono::DateTime<chrono::Utc>,
+                uploaded: String,
                 custom_metadata: Option<HashMap<String, String>>,
             }
 
             let valid = value
                 .as_object()
-                .and_then(|obj| serde_json::from_value::<R2Object>(Value::Object(obj.clone())).ok())
+                .and_then(|obj| R2Object::deserialize(obj).ok())
                 .is_some();
             if valid {
                 Some(value)
@@ -310,18 +308,17 @@ pub fn validate_cidl_type(
         }
 
         CidlType::Array(cidl_type) => {
-            if !value.is_array() {
+            let Value::Array(arr) = value else {
                 fail!(type_mismatch_err(value));
-            }
-            let arr = value.as_array().unwrap();
-            let mut new_arr = Vec::<Value>::new();
+            };
+            let mut new_arr = Vec::<Value>::with_capacity(arr.len());
             let field = ValidatedField {
                 name: field.name.clone(),
                 cidl_type: *cidl_type.clone(),
                 validators: field.validators.clone(),
             };
             for item in arr {
-                let res = validate_cidl_type(&field, Some(item.clone()), idl, is_partial)?;
+                let res = validate_cidl_type(&field, Some(item), idl, is_partial)?;
                 if let Some(res) = res {
                     new_arr.push(res);
                 }
@@ -464,7 +461,9 @@ fn run_validators(value: &Value, validators: &[Validator]) -> Result<(), OrmErro
             }
             Validator::Regex(r) => {
                 let value_str = value.as_str().expect("type validation to have run");
-                if !regex::Regex::new(r).unwrap().is_match(value_str) {
+                // TODO: this recompiles the regex on every value (once per array
+                // element).
+                if !regex_lite::Regex::new(r).unwrap().is_match(value_str) {
                     fail!(OrmErrorKind::UnmatchedRegex {
                         got: value.clone(),
                         pattern: r.to_string(),
@@ -475,4 +474,138 @@ fn run_validators(value: &Value, validators: &[Validator]) -> Result<(), OrmErro
     }
 
     Ok(())
+}
+
+// Adapted from chrono 0.4.44 (MIT/Apache-2.0, Copyright 2014--2026 Kang Seonghoon and contributors)
+// https://github.com/chronotope/chrono
+// See: src/format/parse.rs `parse_rfc3339`, `digit`
+// See: src/format/scan.rs `nanosecond`, `timezone_offset`
+fn is_valid_rfc3339(s: &str) -> bool {
+    let b = s.as_bytes();
+    if b.len() < 19 {
+        return false;
+    }
+
+    #[inline]
+    fn digit(b: &[u8], i: usize) -> Option<u8> {
+        match b[i] {
+            c @ b'0'..=b'9' => Some(c - b'0'),
+            _ => None,
+        }
+    }
+
+    // date-fullyear "-" date-month "-" date-mday
+    let _year = (|| {
+        Some(
+            digit(b, 0)? as u16 * 1000
+                + digit(b, 1)? as u16 * 100
+                + digit(b, 2)? as u16 * 10
+                + digit(b, 3)? as u16,
+        )
+    })();
+    if b[4] != b'-' {
+        return false;
+    }
+    let month = (|| Some(digit(b, 5)? * 10 + digit(b, 6)?))();
+    if b[7] != b'-' {
+        return false;
+    }
+    let day = (|| Some(digit(b, 8)? * 10 + digit(b, 9)?))();
+
+    let (Some(_year), Some(month), Some(day)) = (_year, month, day) else {
+        return false;
+    };
+    if !(1..=12).contains(&month) || !(1..=31).contains(&day) {
+        return false;
+    }
+
+    // "T" / "t" / " "
+    if !matches!(b[10], b'T' | b't' | b' ') {
+        return false;
+    }
+
+    // time-hour ":" time-minute ":" time-second
+    let hour = (|| Some(digit(b, 11)? * 10 + digit(b, 12)?))();
+    if b[13] != b':' {
+        return false;
+    }
+    let min = (|| Some(digit(b, 14)? * 10 + digit(b, 15)?))();
+    if b[16] != b':' {
+        return false;
+    }
+    let sec = (|| Some(digit(b, 17)? * 10 + digit(b, 18)?))();
+
+    let (Some(hour), Some(min), Some(sec)) = (hour, min, sec) else {
+        return false;
+    };
+    // sec == 60 is allowed for leap seconds per RFC 3339
+    if hour > 23 || min > 59 || sec > 60 {
+        return false;
+    }
+
+    // [time-secfrac]: "." 1*DIGIT
+    let mut i = 19;
+    if b.get(i) == Some(&b'.') {
+        i += 1;
+        if i >= b.len() || !b[i].is_ascii_digit() {
+            return false;
+        }
+        while i < b.len() && b[i].is_ascii_digit() {
+            i += 1;
+        }
+    }
+
+    // time-offset: "Z" / time-numoffset
+    match b.get(i) {
+        Some(b'Z' | b'z') => i += 1,
+        Some(b'+' | b'-') => {
+            // time-numoffset: ("+" / "-") time-hour ":" time-minute
+            if i + 6 > b.len() {
+                return false;
+            }
+            let oh = (|| Some(digit(b, i + 1)? * 10 + digit(b, i + 2)?))();
+            let om = (|| Some(digit(b, i + 4)? * 10 + digit(b, i + 5)?))();
+            match (oh, om) {
+                (Some(oh), Some(om)) if oh <= 23 && om <= 59 && b[i + 3] == b':' => {}
+                _ => return false,
+            }
+            i += 6;
+        }
+        _ => return false,
+    }
+
+    i == b.len()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_valid_rfc3339;
+
+    #[test]
+    fn valid_rfc3339() {
+        assert!(is_valid_rfc3339("2024-01-15T10:30:00Z"));
+        assert!(is_valid_rfc3339("2024-01-15t10:30:00z"));
+        assert!(is_valid_rfc3339("2024-01-15 10:30:00Z"));
+        assert!(is_valid_rfc3339("2024-01-15T10:30:00+05:30"));
+        assert!(is_valid_rfc3339("2024-01-15T10:30:00-08:00"));
+        assert!(is_valid_rfc3339("2024-01-15T10:30:00.123Z"));
+        assert!(is_valid_rfc3339("2024-01-15T10:30:00.123456789Z"));
+        assert!(is_valid_rfc3339("2024-01-15T23:59:60Z")); // leap second
+    }
+
+    #[test]
+    fn invalid_rfc3339() {
+        assert!(!is_valid_rfc3339(""));
+        assert!(!is_valid_rfc3339("not-a-date"));
+        assert!(!is_valid_rfc3339("2024-01-15 10:30:00")); // missing timezone
+        assert!(!is_valid_rfc3339("2024-01-15T10:30:00")); // missing timezone
+        assert!(!is_valid_rfc3339("2024-13-15T10:30:00Z")); // month 13
+        assert!(!is_valid_rfc3339("2024-01-32T10:30:00Z")); // day 32
+        assert!(!is_valid_rfc3339("2024-01-15T25:30:00Z")); // hour 25
+        assert!(!is_valid_rfc3339("2024-01-15T10:60:00Z")); // minute 60
+        assert!(!is_valid_rfc3339("2024-01-15T10:30:00.Z")); // dot with no digits
+        assert!(!is_valid_rfc3339("2024-01-15T10:30:00Zextra")); // trailing chars
+        assert!(!is_valid_rfc3339("2024-01-15T10:30:00+25:00")); // offset hour 25
+        assert!(!is_valid_rfc3339("2024-01-15T10:30:00+05:60")); // offset min 60
+    }
 }

--- a/src/compiler/semantic/Cargo.toml
+++ b/src/compiler/semantic/Cargo.toml
@@ -7,7 +7,7 @@ ariadne = { workspace = true }
 idl = { path = "../idl" }
 frontend = { path = "../frontend" }
 indexmap = { workspace = true }
-regex = { workspace = true }
+regex-lite = { workspace = true }
 orm = { path = "../orm" }
 
 [dev-dependencies]

--- a/src/compiler/semantic/src/lib.rs
+++ b/src/compiler/semantic/src/lib.rs
@@ -562,7 +562,7 @@ fn resolve_validator_tags<'src, 'p>(
             MinLen => parse_usize(arg, symbol, spd, &mut sink).map(Validator::MinLength),
             MaxLen => parse_usize(arg, symbol, spd, &mut sink).map(Validator::MaxLength),
             Regex => match arg {
-                ArgumentLiteral::Regex(s) => match regex::Regex::new(s) {
+                ArgumentLiteral::Regex(s) => match regex_lite::Regex::new(s) {
                     Ok(_) => Some(Validator::Regex(std::borrow::Cow::Borrowed(s))),
                     Err(e) => {
                         sink.push(SemanticError::ValidatorInvalidArgument {

--- a/src/runtime/ts/package.json
+++ b/src/runtime/ts/package.json
@@ -37,7 +37,7 @@
     "test": "vitest run",
     "typecheck": "tsc --noEmit",
     "build": "tsc -p tsconfig.json && pnpm run copy-rs-orm-wasm",
-    "copy-rs-orm-wasm": "cp ../../../target/wasm32-unknown-unknown/release/orm.wasm ./dist/orm.wasm"
+    "copy-rs-orm-wasm": "cp ../../../target/wasm32-unknown-unknown/wasm-release/orm.wasm ./dist/orm.wasm"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250906.0",


### PR DESCRIPTION
Super basic attempts at reducing wasm size (was 2.2MB)
- Used `regex-lite` instead of `regex` ( -> 1.1 MB)
- Created a release profile for wasm with LTO and other optimizations ( -> 884 KB )
- Removed `index_map` and `chrono` dependencies ( -> 845 KB )
- Fixed extra clones and such around the ORM algorithms

If `wash-opt` was integrated into the build process, the size is reduced to around 640KB.

 I'd also like to look into completely removing `serde` from the ORM and compiler in general, in favor of `rkyv` (removes another 200KB). Reserving both for the future, I think further optimizations should benchmark cold-start times to see if it was worth it in the first place. Optimistic that the ORM could be ~300KB.